### PR TITLE
Adam/cloudtrail processor

### DIFF
--- a/cloudformation.json
+++ b/cloudformation.json
@@ -60,7 +60,7 @@
               {
                 "Action": "sts:AssumeRole",
                 "Principal": {
-                "Service": ["lambda.amazonaws.com","apigateway.amazonaws.com", "logs.amazonaws.com"]
+                "Service": ["lambda.amazonaws.com","apigateway.amazonaws.com", "logs.amazonaws.com", "s3.amazonaws.com"]
               },
              "Effect": "Allow",
              "Sid": ""
@@ -88,7 +88,8 @@
                   "logs:DeleteSubscriptionFilter",
                   "logs:PutLogEvents",
                   "logs:GetLogEvents",
-                  "logs:FilterLogEvents"
+                  "logs:FilterLogEvents",
+                  "s3:*"
                 ],
                 "Resource": "*"
               }
@@ -209,12 +210,76 @@
           "Principal": "logs.amazonaws.com"
         }
     },
-    "HumioAutoSubscriptionS3Bucket": {
+    "HumioCloudTrailProcessor": {
+      "DependsOn": ["HumioLoggingRole"],
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket":  { "Fn::Join": [ "-", [ "humio-public", { "Ref": "AWS::Region" } ] ] },
+          "S3Key": "cloudwatch_humio.zip"
+        },
+        "Environment": {
+          "Variables": {
+            "humio_dataspace_name": { "Ref": "HumioDataspaceName" },
+            "humio_protocol": { "Ref": "HumioProtocol" },
+            "humio_host": { "Ref": "HumioHost" },
+            "humio_ingest_token": { "Ref": "HumioIngestToken" }
+          }
+        },
+        "Description": "humio cloudtrail processor",
+        "Handler": "cloudtrail_processor.lambda_handler",
+        "MemorySize": "128",
+        "Role": { "Fn::GetAtt": [ "HumioLoggingRole", "Arn" ] },
+        "Runtime": "python2.7",
+        "Timeout": "300"
+      }
+    },
+    "HumioCloudTrailProcessorPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "DependsOn": "HumioCloudTrailProcessor",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "HumioCloudTrailProcessor",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:*",
+        "Principal": "s3.amazonaws.com",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        }
+      }
+    },
+   "HumioAutoSubscriptionS3Bucket": {
       "Type" : "AWS::S3::Bucket",
       "Condition" : "CreateAutoSubscriptionResources",
       "Properties" : {
         "AccessControl" : "BucketOwnerFullControl",
-        "BucketName" : {"Fn::Join": [ "-", [ "humio", { "Ref": "AWS::StackName" } , "cloudtrail"]]}
+        "BucketName" : {"Fn::Join": [ "-", [ "humio", { "Ref": "AWS::StackName" } , "cloudtrail"]]},
+        "NotificationConfiguration": {
+        "LambdaConfigurations": [
+          {
+            "Event": "s3:ObjectCreated:*",
+              "Filter": {
+                "S3Key": {
+                  "Rules": [
+                    {
+                      "Name": "suffix",
+                      "Value": "gz"
+                    }
+                  ]
+                }
+              },
+              "Function": {
+                "Fn::GetAtt": [
+                  "HumioCloudTrailProcessor",
+                  "Arn"
+                ]
+              }
+            }
+          ]
+        }
       }
     },
     "HumioAutoSubscriptionS3BucketPolicy" : {

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+cat cloudformation.json | jq
+make target/cloudwatch_humio.zip
+aws s3 cp --acl public-read cloudformation.json s3://humio-public-us-east-1/
+aws s3 cp --acl public-read cloudformation.json s3://humio-public-us-east-2/
+aws s3 cp --acl public-read cloudformation.json s3://humio-public-eu-central-1/
+aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-eu-central-1/
+aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-east-1/
+aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-east-2/

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 set -e
 cat cloudformation.json | jq
-make target/cloudwatch_humio.zip
+make build 
 aws s3 cp --acl public-read cloudformation.json s3://humio-public-us-east-1/
-aws s3 cp --acl public-read cloudformation.json s3://humio-public-us-east-2/
-aws s3 cp --acl public-read cloudformation.json s3://humio-public-eu-central-1/
 aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-eu-central-1/
 aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-east-1/
 aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-east-2/

--- a/lambdas/cloudtrail_processor.py
+++ b/lambdas/cloudtrail_processor.py
@@ -1,0 +1,67 @@
+import json
+import os
+import time
+import base64
+import gzip
+import boto3
+import StringIO
+import urllib2
+
+def humio_ingest(decoded_event):
+    humio_host = os.environ['humio_host']
+    humio_protocol = os.environ['humio_protocol']
+    humio_dataspace = os.environ['humio_dataspace_name']
+    humio_ingest_token = os.environ['humio_ingest_token']
+
+    humio_url = '%s://%s/api/v1/dataspaces/%s/ingest' % (humio_protocol, humio_host, humio_dataspace)
+    humio_headers = {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer %s' % humio_ingest_token
+    }
+    
+    # flatten the events from cloudwatch
+    humio_events = []
+
+    for record in decoded_event['Records']:
+        
+        # Append the flattened event
+        humio_events.append({
+            'timestamp': record['eventTime'],
+            'attributes': record
+        })
+
+    # Make a batch for the Humio ingest API
+    wrapped_data = [{ 'tags': {'service':'cloudtrail'}, 'events': humio_events }]
+    
+    # prepare request
+    request = urllib2.Request(humio_url, json.dumps(wrapped_data), humio_headers)
+    
+    # ship request
+    f = urllib2.urlopen(request)
+
+    # read response
+    response = f.read()
+
+    # close handler
+    f.close()
+
+    # debug output
+    print('got response %s from humio' % response)
+
+
+def lambda_handler(event, context):
+
+    s3 = boto3.resource('s3')
+    
+    for record in event['Records']: 
+      bucket = s3.Bucket(record['s3']['bucket']['name'])
+      try:
+          bucket.download_file(record['s3']['object']['key'], '/tmp/cloudtrail.txt')
+          with gzip.open('/tmp/cloudtrail.txt', 'r') as data:
+            decoded_json_event = data.read()
+            decoded_event = json.loads(decoded_json_event)
+            humio_ingest(decoded_event)
+            os.remove('/tmp/cloudtrail.txt')
+
+      except Exception as e:
+          raise


### PR DESCRIPTION
Adding first pass at a cloudtrail processing lamba. Next steps are to refactor this and `ingester.py` to share ingestion functions and remove duplicate code.

Events should be coming through fully parsed like so
<img width="962" alt="screen shot 2017-12-19 at 4 31 05 am" src="https://user-images.githubusercontent.com/1205898/34150164-86157aec-e475-11e7-9d8b-659ea2b954b6.png">
