### PR TITLE
Changing stackname reference to account id making installs unique

### DIFF
--- a/cloudformation.json
+++ b/cloudformation.json
@@ -256,7 +256,7 @@
       "Condition" : "CreateAutoSubscriptionResources",
       "Properties" : {
         "AccessControl" : "BucketOwnerFullControl",
-        "BucketName" : {"Fn::Join": [ "-", [ "humio", { "Ref": "AWS::StackName" } , "cloudtrail"]]},
+        "BucketName" : {"Fn::Join": [ "-", [ "humio", { "Ref": "AWS::AccountId" } , "cloudtrail"]]},
         "NotificationConfiguration": {
         "LambdaConfigurations": [
           {
@@ -319,8 +319,8 @@
         "IncludeGlobalServiceEvents" : true,
         "IsMultiRegionTrail" : true,
         "IsLogging": true,
-        "S3BucketName" : {"Fn::Join": [ "-", [ "humio", { "Ref": "AWS::StackName" } , "cloudtrail"]]},
-        "TrailName" : {"Fn::Join": [ "-", [ "humio", { "Ref": "AWS::StackName" } ]]}
+        "S3BucketName" : {"Fn::Join": [ "-", [ "humio", { "Ref": "AWS::AccountId" } , "cloudtrail"]]},
+        "TrailName" : {"Fn::Join": [ "-", [ "humio", { "Ref": "AWS::AccountId" } ]]}
       }
     },
     "HumioAutoSubscriptionEventRule": {


### PR DESCRIPTION
Changing `StackName` to `AccountId`. Required s3 buckets will now be made with the account id instead of the default stack name. This should fix any install issues we're having as reported in https://github.com/humio/cloudwatch2humio/issues/4.