### PR TITLE
Feature/python 3

### DIFF
--- a/lambdas/auto_subscriber.py
+++ b/lambdas/auto_subscriber.py
@@ -4,23 +4,28 @@ import json
 import os
 import helpers
 
+
 def lambda_handler(event, context):
-    
+
     # setup log client
-    log_client = boto3.client('logs')
+    log_client = boto3.client("logs")
 
     # grab log group name from incoming event
-    log_group_name = event['detail']['requestParameters']['logGroupName'] 
+    log_group_name = event["detail"]["requestParameters"]["logGroupName"]
 
-    # env vars 
-    humio_log_ingester_arn = os.environ['humio_log_ingester_arn']
-    humio_subscription_prefix = os.environ['humio_subscription_prefix']
-  
+    # env vars
+    humio_log_ingester_arn = os.environ["humio_log_ingester_arn"]
+    humio_subscription_prefix = os.environ.get("humio_subscription_prefix")
+
     # check if the prefix is empty
     if not humio_subscription_prefix:
-        helpers.create_subscription(log_client, log_group_name, humio_log_ingester_arn, context)
+        helpers.create_subscription(
+            log_client, log_group_name, humio_log_ingester_arn, context
+        )
 
     else:
         # check if log group name starts with our prefix
         if log_group_name.startswith(humio_subscription_prefix):
-            helpers.create_subscription(log_client, log_group_name, humio_log_ingester_arn, context)
+            helpers.create_subscription(
+                log_client, log_group_name, humio_log_ingester_arn, context
+            )

--- a/lambdas/backfiller.py
+++ b/lambdas/backfiller.py
@@ -6,65 +6,77 @@ import helpers
 from time import sleep
 
 # setup log client
-log_client = boto3.client('logs')
+log_client = boto3.client("logs")
 
 # env vars
-humio_log_ingester_arn = os.environ['humio_log_ingester_arn']
-humio_subscription_prefix = os.environ['humio_subscription_prefix']
+humio_log_ingester_arn = os.environ["humio_log_ingester_arn"]
+humio_subscription_prefix = os.environ.get("humio_subscription_prefix")
 
 # long running function that lists all log groups and subscribes to them
 def lambda_handler(event, context):
 
-  # grab all log groups with a token if we have it
-  if 'nextToken' in event.keys():
-      nextToken=event['nextToken']
-      if humio_subscription_prefix:
-          log_groups = log_client.describe_log_groups(
-              logGroupNamePrefix=humio_subscription_prefix,
-              nextToken=nextToken
-          )
-      else:
-          log_groups = log_client.describe_log_groups(
-              nextToken=nextToken
-          )
-  else:
-      if humio_subscription_prefix:
-          log_groups = log_client.describe_log_groups(
-              logGroupNamePrefix=humio_subscription_prefix,
-          )
-      else:
-          log_groups = log_client.describe_log_groups(
-          )
+    # grab all log groups with a token if we have it
+    if "nextToken" in event.keys():
+        nextToken = event["nextToken"]
+        if humio_subscription_prefix:
+            log_groups = log_client.describe_log_groups(
+                logGroupNamePrefix=humio_subscription_prefix, nextToken=nextToken
+            )
+        else:
+            log_groups = log_client.describe_log_groups(nextToken=nextToken)
+    else:
+        if humio_subscription_prefix:
+            log_groups = log_client.describe_log_groups(
+                logGroupNamePrefix=humio_subscription_prefix
+            )
+        else:
+            log_groups = log_client.describe_log_groups()
 
-  # if we have a token, recursively fire another instance of backfiller with it
-  if 'nextToken' in log_groups.keys():
-      lambda_cli = boto3.client("lambda")
-      event['nextToken'] = log_groups['nextToken']
-      lambda_cli.invoke_async(FunctionName=context.function_name, InvokeArgs=json.dumps(event))
+    # if we have a token, recursively fire another instance of backfiller with it
+    if "nextToken" in log_groups.keys():
+        lambda_cli = boto3.client("lambda")
+        event["nextToken"] = log_groups["nextToken"]
+        lambda_cli.invoke_async(
+            FunctionName=context.function_name, InvokeArgs=json.dumps(event)
+        )
 
-  # loop through log groups
-  for logGroup in log_groups['logGroups']:
+    # loop through log groups
+    for logGroup in log_groups["logGroups"]:
 
-      # grab all subscriptions for the specified log group
-      all_subscription_filters = log_client.describe_subscription_filters(
-        logGroupName=logGroup['logGroupName']
-      )
-    
-      # first we check to see if there are any filters at all
-      if all_subscription_filters['subscriptionFilters']:
+        # grab all subscriptions for the specified log group
+        all_subscription_filters = log_client.describe_subscription_filters(
+            logGroupName=logGroup["logGroupName"]
+        )
 
-          # if our function is not subscribed delete subscription and create ours
-          if all_subscription_filters['subscriptionFilters'][0]['destinationArn'] != humio_log_ingester_arn:
-              helpers.delete_subscription(log_client, logGroup['logGroupName'], all_subscription_filters['subscriptionFilters'][0]['filterName'])
-              helpers.create_subscription(log_client, logGroup['logGroupName'], humio_log_ingester_arn, context)
+        # first we check to see if there are any filters at all
+        if all_subscription_filters["subscriptionFilters"]:
 
-          # we are subbed
-          else:
-              print("We are subscribed to %s" % logGroup['logGroupName'])
+            # if our function is not subscribed delete subscription and create ours
+            if (
+                all_subscription_filters["subscriptionFilters"][0]["destinationArn"]
+                != humio_log_ingester_arn
+            ):
+                helpers.delete_subscription(
+                    log_client,
+                    logGroup["logGroupName"],
+                    all_subscription_filters["subscriptionFilters"][0]["filterName"],
+                )
+                helpers.create_subscription(
+                    log_client,
+                    logGroup["logGroupName"],
+                    humio_log_ingester_arn,
+                    context,
+                )
 
-      # there are no filters, lets subscribe!
-      else:
-          helpers.create_subscription(log_client, logGroup['logGroupName'], humio_log_ingester_arn, context)
+            # we are subbed
+            else:
+                print("We are subscribed to %s" % logGroup["logGroupName"])
 
-      # keep hitting rate limits? TODO: find actual limits and back off using those 
-      sleep(0.8)
+        # there are no filters, lets subscribe!
+        else:
+            helpers.create_subscription(
+                log_client, logGroup["logGroupName"], humio_log_ingester_arn, context
+            )
+
+        # keep hitting rate limits? TODO: find actual limits and back off using those
+        sleep(0.8)

--- a/lambdas/backfiller.py
+++ b/lambdas/backfiller.py
@@ -5,8 +5,6 @@ import os
 import helpers
 from time import sleep
 
-from StringIO import StringIO
-
 # setup log client
 log_client = boto3.client('logs')
 

--- a/lambdas/helpers.py
+++ b/lambdas/helpers.py
@@ -1,25 +1,25 @@
 def create_subscription(log_client, log_group_name, humio_log_ingester_arn, context):
-    
+
     # can't subscribe to the log group that our stdout/err goes to
     if context.log_group_name == log_group_name:
         print("Skipping our own log group name...")
     else:
         print("Creating subscription for %s" % log_group_name)
-	try:
-            response = log_client.put_subscription_filter(
-                logGroupName=log_group_name,
-                filterName="%s-humio_ingester" % log_group_name,
-                filterPattern='',
-                destinationArn=humio_log_ingester_arn,
-                distribution='ByLogStream'
-            )
-            print('subscribed to %s!' % log_group_name)
-	except Exception as e:
-	    print('Error creating subscription to %s. Exception: %s' % (log_group_name, e))
+    try:
+        response = log_client.put_subscription_filter(
+            logGroupName=log_group_name,
+            filterName="%s-humio_ingester" % log_group_name,
+            filterPattern="",
+            destinationArn=humio_log_ingester_arn,
+            distribution="ByLogStream",
+        )
+        print("subscribed to %s!" % log_group_name)
+    except Exception as e:
+        print("Error creating subscription to %s. Exception: %s" % (log_group_name, e))
+
 
 def delete_subscription(log_client, logGroupName, filterName):
     print("Deleting subscription for %s" % logGroupName)
     response = log_client.delete_subscription_filter(
-        logGroupName=logGroupName,
-        filterName=filterName
+        logGroupName=logGroupName, filterName=filterName
     )

--- a/lambdas/helpers.py
+++ b/lambdas/helpers.py
@@ -1,8 +1,3 @@
-def decode_event(event):
-    decoded_json_event = gzip.GzipFile(fileobj=StringIO(event['awslogs']['data'].decode('base64','strict'))).read()
-    decoded_event = json.loads(decoded_json_event)
-    return decoded_event
-
 def create_subscription(log_client, log_group_name, humio_log_ingester_arn, context):
     
     # can't subscribe to the log group that our stdout/err goes to

--- a/lambdas/ingester.py
+++ b/lambdas/ingester.py
@@ -14,44 +14,55 @@ from time import sleep
 from datetime import tzinfo
 
 import sys
-if sys.version_info >= (3,2):
+
+if sys.version_info >= (3, 2):
     # Python 3 imports
     from urllib.request import Request, urlopen
-    
+
     # gzip decompress was introduced in python 3.2 - earlier 3.X versions are therefore not supported
     def gzip_decode(event):
-        return gzip.decompress(base64.b64decode(event['awslogs']['data']))
+        return gzip.decompress(base64.b64decode(event["awslogs"]["data"]))
+
+
 else:
     # Old Python 2.7 imports
     from urllib2 import Request, urlopen
     from StringIO import StringIO
+
     def gzip_decode(event):
-        return gzip.GzipFile(fileobj=StringIO(event['awslogs']['data'].decode('base64','strict'))).read()
+        return gzip.GzipFile(
+            fileobj=StringIO(event["awslogs"]["data"].decode("base64", "strict"))
+        ).read()
 
 
 ################################################################################
 ### The main handler ###########################################################
 ################################################################################
 
+
 def lambda_handler(event, context):
-   
+
     ################################################################################
     ### Parameters for the lambda ##################################################
     ################################################################################
 
-    humio_host = os.environ['humio_host']
-    humio_protocol = os.environ['humio_protocol']
-    humio_dataspace = os.environ['humio_dataspace_name']
-    humio_ingest_token = os.environ['humio_ingest_token']
+    humio_host = os.environ["humio_host"]
+    humio_protocol = os.environ["humio_protocol"]
+    humio_dataspace = os.environ["humio_dataspace_name"]
+    humio_ingest_token = os.environ["humio_ingest_token"]
 
     ################################################################################
     ### Global variables ###########################################################
     ################################################################################
 
-    humio_url = '%s://%s/api/v1/dataspaces/%s/ingest' % (humio_protocol, humio_host, humio_dataspace)
+    humio_url = "%s://%s/api/v1/dataspaces/%s/ingest" % (
+        humio_protocol,
+        humio_host,
+        humio_dataspace,
+    )
     humio_headers = {
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer %s' % humio_ingest_token
+        "Content-Type": "application/json",
+        "Authorization": "Bearer %s" % humio_ingest_token,
     }
 
     # decode and unzip the log data
@@ -61,47 +72,49 @@ def lambda_handler(event, context):
     # debug output
     print("Event from Cloudwatch: %s" % (json.dumps(decoded_event)))
 
-
     # Extract general attributes from the event batch
     batch_attrs = {
-        'owner': decoded_event.get('owner', 'undefined'),
-        'logGroup': decoded_event.get('logGroup', 'undefined'),
-        'logStream': decoded_event.get('logStream', 'undefined'),
-        'messageType': decoded_event.get('messageType', 'undefined'),
-        'subscriptionFilters': decoded_event.get('subscriptionFilters', 'undefined')
+        "owner": decoded_event.get("owner", "undefined"),
+        "logGroup": decoded_event.get("logGroup", "undefined"),
+        "logStream": decoded_event.get("logStream", "undefined"),
+        "messageType": decoded_event.get("messageType", "undefined"),
+        "subscriptionFilters": decoded_event.get("subscriptionFilters", "undefined"),
     }
 
-    # parse out the service name 
-    logGroupParser = re.compile('^/aws/(lambda|apigateway)/(.*)')
- 
-    parsedLogGroup = logGroupParser.match(decoded_event.get('logGroup', ""))
+    # parse out the service name
+    logGroupParser = re.compile("^/aws/(lambda|apigateway)/(.*)")
+
+    parsedLogGroup = logGroupParser.match(decoded_event.get("logGroup", ""))
     if parsedLogGroup:
         batch_attrs.update(
             {
-                'awsServiceName': parsedLogGroup.group(1),
-                'parsedLogGroupName': parsedLogGroup.group(2)
-            })
+                "awsServiceName": parsedLogGroup.group(1),
+                "parsedLogGroupName": parsedLogGroup.group(2),
+            }
+        )
 
     # flatten the events from cloudwatch
     humio_events = []
-    for logEvent in decoded_event['logEvents']:
-        message = logEvent['message']
+    for logEvent in decoded_event["logEvents"]:
+        message = logEvent["message"]
 
         # Create the attributes
-        attributes={}
+        attributes = {}
         attributes.update(batch_attrs)
         attributes.update(parse_message(message))
 
         # Append the flattened event
-        humio_events.append({
-            'timestamp': logEvent['timestamp'],
-            'rawstring': message,
-            'kvparse': True,
-            'attributes': attributes,
-        })
+        humio_events.append(
+            {
+                "timestamp": logEvent["timestamp"],
+                "rawstring": message,
+                "kvparse": True,
+                "attributes": attributes,
+            }
+        )
 
     # Make a batch for the Humio ingest API
-    wrapped_data = [{ 'tags': {'host':'lambda'}, 'events': humio_events }]
+    wrapped_data = [{"tags": {"host": "lambda"}, "events": humio_events}]
 
     # prepare request
     request = Request(humio_url, json.dumps(wrapped_data).encode(), humio_headers)
@@ -115,32 +128,38 @@ def lambda_handler(event, context):
     f.close()
 
     # debug output
-    print('got response %s from humio' % response)
+    print("got response %s from humio" % response)
+
 
 ################################################################################
 ### Simple Cloudwatch parser ###################################################
 ################################################################################
 
-#Standard out from lambdas
-std_matcher = re.compile('\d\d\d\d-\d\d-\d\d\S+\s+(?P<request_id>\S+)')
+# Standard out from lambdas
+std_matcher = re.compile("\d\d\d\d-\d\d-\d\d\S+\s+(?P<request_id>\S+)")
 
-#END RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46
-end_matcher = re.compile('END RequestId:\s+(?P<request_id>\S+)')
+# END RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46
+end_matcher = re.compile("END RequestId:\s+(?P<request_id>\S+)")
 
-#START RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46 Version: $LATEST
-start_matcher = re.compile('START RequestId:\s+(?P<request_id>\S+)\s+Version: (?P<version>\S+)')
+# START RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46 Version: $LATEST
+start_matcher = re.compile(
+    "START RequestId:\s+(?P<request_id>\S+)\s+Version: (?P<version>\S+)"
+)
 
-#REPORT RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46	Duration: 0.47 ms	Billed Duration: 100 ms Memory Size: 128 MB	Max Memory Used: 20 MB
-report_matcher = re.compile('REPORT RequestId:\s+(?P<request_id>\S+)\s+Duration: (?P<duration>\S+) ms\s+Billed Duration: (?P<billed_duration>\S+) ms\s+Memory Size: (?P<memory_size>\S+) MB\s+Max Memory Used: (?P<max_memory>\S+) MB')
+# REPORT RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46	Duration: 0.47 ms	Billed Duration: 100 ms Memory Size: 128 MB	Max Memory Used: 20 MB
+report_matcher = re.compile(
+    "REPORT RequestId:\s+(?P<request_id>\S+)\s+Duration: (?P<duration>\S+) ms\s+Billed Duration: (?P<billed_duration>\S+) ms\s+Memory Size: (?P<memory_size>\S+) MB\s+Max Memory Used: (?P<max_memory>\S+) MB"
+)
+
 
 def parse_message(message):
     m = None
 
-    if message.startswith('END'):
+    if message.startswith("END"):
         m = end_matcher.match(message)
-    elif message.startswith('START'):
+    elif message.startswith("START"):
         m = start_matcher.match(message)
-    elif message.startswith('REPORT'):
+    elif message.startswith("REPORT"):
         m = report_matcher.match(message)
     else:
         m = std_matcher.match(message)
@@ -150,15 +169,16 @@ def parse_message(message):
     else:
         return {}
 
+
 ### Some manual cli-testing of the parse_message function
 #
-#def p(s):
+# def p(s):
 #    print (s)
 #
-#p(parse_message("2017-08-28T09:49:48.176Z 3aaf5224-8bd6-11e7-bb30-4f271af95c46 { message: 'humming right along {O,o} ' }"))
-#p(parse_message("END RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46"))
-#p(parse_message("START RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46 Version: $LATEST"))
-#p(parse_message("REPORT RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46	Duration: 0.47 ms Billed Duration: 100 ms Memory Size: 128 MB Max Memory Used: 20 MB"))
+# p(parse_message("2017-08-28T09:49:48.176Z 3aaf5224-8bd6-11e7-bb30-4f271af95c46 { message: 'humming right along {O,o} ' }"))
+# p(parse_message("END RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46"))
+# p(parse_message("START RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46 Version: $LATEST"))
+# p(parse_message("REPORT RequestId: b3be449c-8bd7-11e7-bb30-4f271af95c46	Duration: 0.47 ms Billed Duration: 100 ms Memory Size: 128 MB Max Memory Used: 20 MB"))
 
 # This is a seperate handler and not called at all through the normal ingestion execution flow
 # update subscriptions before our next run


### PR DESCRIPTION
This should make the code Python 3.2+ compliant, while still working on Python 2.7 (at least for a little while longer, to give people time to migrate).

This should also fix a mixed tabs and spaces error in `helpers.py` which might've caused `auto_subscriber.py` and `backfiller.py` to not work properly.

Only the `ingester.py` script has actually been tested in AWS though, so any testing of the remaining scripts would be greatly appreciated.