### PR TITLE
Cloudwatch metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 .vscode/
 venv/
 target/
-deploy.sh
 parameters.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 .vscode/
 venv/
 target/
+deploy.sh
 parameters.json

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ target:
 	mkdir -p target
 
 copy:
-	cp lambdas/* target
+	cp src/* target
 
 dependencies:
-	pip3 install requests -t target
+	pip3 install -r requirements.txt -t target
 
 target/cloudwatch_humio.zip:
 	(cd target/ && zip -r ../target/cloudwatch_humio.zip * )

--- a/README.md
+++ b/README.md
@@ -1,10 +1,71 @@
 
-# cloudwatch2humio
+# CloudWatch2Humio
 
-This repository contains a set of lambdas for shipping Cloudwatch Logs
+This repository contains a set of lambdas for shipping Cloudwatch Logs and Metrics
 to Humio.
 
-For usage documentation see:
+For making a quick launch see the documentation:
 
 https://docs.humio.com/integrations/platform-integrations/aws-cloudwatch/
+
+For a manual set up, follow along with this guide! 
+
+## Manual Setup
+
+This integration uses CloudFormation to set up a set of lambda functions which can retrieve logs and metrics from CloudWatch. 
+
+### Prerequisites
+
+* AWS CLI installed and setup with an AWS account allowed to create a CloudFormation stack. 
+
+### Setup
+
+#### 1. Create a zip file with the content of the **src** folder
+
+On linux:
+
+> $ make
+
+On windows:
+
+1. Create a folder named **target** in root, and copy all files from **src** into it.
+2. Install requirements into the **target** folder using pip:
+
+    > pip3 install -r requirements.txt -t target
+
+3. In the **target** folder, zip all files into **cloudwatch_humio.zip**. 
+
+#### 2. Create an AWS S3 bucket
+
+The name of the AWS S3 bucket must be the same as the one specified in the CloudFormation file, beware of this if you choose another name.
+
+> $ aws s3api create-bucket --bucket humio-public-REGION --create-bucket-configuration LocationConstraint=REGION
+
+#### 3. Upload zip file to AWS S3 bucket. 
+
+> $ aws s3 cp target/cloudwatch_humio.zip s3://humio-public-REGION/
+
+#### 4. Create JSON file and define paramters.
+
+Create a **parameters.json** file in the root folder, and at least specify the following parameters:
+
+> {
+>   "ParameterName": "HumioIngestToken",
+>   "ParameterValue": "YOUR-SECRET-INGEST-TOKEN"
+> }
+
+Look in the CloudFormation file to see the other parameters available. 
+
+#### 5. Create stack.
+
+To create the stack using the CloudFormation file and the parameters that you have defined run:
+
+> $ aws cloudformation create-stack --stack-name STACK-NAME --template-body file://cloudformation.json --parameters file://parameters.json --capabilities CAPABILITY_IAM --debug --region REGION
+
+#### 6. (Optional) Delete stack.
+
+If you want to delete the stack, then run the following command: 
+
+> $ aws cloudformation delete-stack --stack-name STACK-NAME
+
 

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -1,37 +1,32 @@
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
   "Parameters" : {
-    "HumioRepositoryName" : {
-      "Type" : "String",
-      "Description" : "The name of your repository in Humio that you want to ship logs to.",
-      "Default" : ""
-    },
     "HumioProtocol" : {
       "Type" : "String",
-      "Description" : "The transport protocol used for delivering log events to Humio. HTTPS is default and recommended.",
+      "Description" : "The transport protocol used for delivering log/metric events to Humio. HTTPS is default and recommended.",
       "Default" : "https"
     },
     "HumioHost" : {
       "Type" : "String",
-      "Description" : "The host you want to ship your Humio logs to.",
+      "Description" : "The host to ship Humio logs/metrics to.",
       "Default" : "cloud.humio.com"
     },
     "HumioIngestToken" : {
       "Type" : "String",
-      "Description" : "The value of your ingest token from your Humio account.",
+      "Description" : "The value of the ingest token for the repository to ship logs/metrics to from your Humio account.",
       "Default" : "",
       "NoEcho" : true
     },
-    "HumioAutoSubscription" : {
+    "HumioCloudWatchLogsAutoSubscription" : {
       "Type" : "String",
       "AllowedValues" : [
         "true",
         "false"
       ],
       "Default" : "true",
-      "Description" : "The Humio Ingester will automatically subscribe to new log groups you specify with the prefix below. Set to 'true' to enable."
+      "Description" : "Enabling this will make the logs ingester automatically subscribe to new log groups specified with the prefix below. Set to 'true' to enable."
     },
-    "HumioSubscriptionBackfiller" : {
+    "HumioCloudWatchLogsBackfillerSubscription" : {
       "Type" : "String",
       "AllowedValues" : [
         "true",
@@ -40,19 +35,19 @@
       "Default" : "true",
       "Description" : "Enabling this will backfill older log groups that existed before Humio was installed. This will run every time a new log group is created."
     },
-    "HumioSubscriptionPrefix" : {
+    "HumioCloudWatchLogsSubscriptionPrefix" : {
       "Type" : "String",
-      "Description" : "Humio will only subscribe to log groups with the prefix you specify.",
+      "Description" : "Humio will only subscribe to log groups with the prefix specified.",
       "Default" : ""
     }
   },
   "Conditions" : {
-    "CreateAutoSubscriptionResources" : {
-      "Fn::Equals" : [ { "Ref" : "HumioAutoSubscription" }, "true" ]
+    "CreateHumioCloudWatchLogsAutoSubscriptionResources" : {
+      "Fn::Equals" : [ { "Ref" : "HumioCloudWatchLogsAutoSubscription" }, "true" ]
     }
   },
   "Resources" : {
-    "HumioLoggingRole" : {
+    "HumioCloudWatchRole" : {
       "Type" : "AWS::IAM::Role",
       "Properties" : {
         "AssumeRolePolicyDocument" : {
@@ -74,7 +69,7 @@
         }, 
         "Policies" : [
           {
-            "PolicyName" : "humio_logging_role",
+            "PolicyName" : "humio_cloudwatch_role",
             "PolicyDocument" : {
               "Version" : "2012-10-17",
               "Statement" : [
@@ -92,7 +87,9 @@
                     "logs:DeleteSubscriptionFilter",
                     "logs:PutLogEvents",
                     "logs:GetLogEvents",
-                    "logs:FilterLogEvents"
+                    "logs:FilterLogEvents",
+                    "cloudwatch:GetMetricData",
+                    "cloudwatch:GetMetricStatistics"
                   ],
                   "Resource" : "*"
                 }
@@ -102,8 +99,8 @@
         ]
       }
     },
-    "HumioCloudwatchIngester" : {
-      "DependsOn" : [ "HumioLoggingRole" ],
+    "HumioCloudWatchLogsIngester" : {
+      "DependsOn" : [ "HumioCloudWatchRole" ],
       "Type" : "AWS::Lambda::Function",
       "Properties" : {
         "Code" : {
@@ -114,35 +111,34 @@
         },
         "Environment" : {
           "Variables" : {
-            "humio_repository_name" : { "Ref" : "HumioRepositoryName" },
             "humio_protocol" : { "Ref" : "HumioProtocol" },
             "humio_host" : { "Ref" : "HumioHost" },
             "humio_ingest_token" : { "Ref" : "HumioIngestToken" },
-            "humio_subscription_enable" : { "Ref" : "HumioAutoSubscription" }
+            "humio_subscription_enable" : { "Ref" : "HumioCloudWatchLogsAutoSubscription" }
           }
         },
         "Description" : "CloudWatch Logs to Humio ingester.",
-        "Handler" : "ingester.lambda_handler",
+        "Handler" : "logs_ingester.lambda_handler",
         "MemorySize" : "128",
         "Role" : {
-          "Fn::GetAtt" : [ "HumioLoggingRole", "Arn" ]
+          "Fn::GetAtt" : [ "HumioCloudWatchRole", "Arn" ]
         },
         "Runtime" : "python3.8",
         "Timeout" : "300"
       }
     },
-    "HumioCloudwatchIngesterPermission" : {
+    "HumioCloudWatchLogsIngesterPermission" : {
       "Type" : "AWS::Lambda::Permission",
       "Properties" : {
         "Action" : "lambda:InvokeFunction",
         "FunctionName" : {
-          "Fn::GetAtt" : [ "HumioCloudwatchIngester", "Arn" ]
+          "Fn::GetAtt" : [ "HumioCloudWatchLogsIngester", "Arn" ]
         },
         "Principal" : "logs.amazonaws.com"
       }
     },
-    "HumioCloudwatchAutoSubscriber" : {
-      "DependsOn" : [ "HumioLoggingRole" ],
+    "HumioCloudWatchLogsSubscriber" : {
+      "DependsOn" : [ "HumioCloudWatchRole" ],
       "Type" : "AWS::Lambda::Function",
       "Properties" : {
         "Code" : {
@@ -154,50 +150,50 @@
         "Environment" : {
           "Variables" : {
             "humio_log_ingester_arn" : {
-              "Fn::GetAtt" : [ "HumioCloudwatchIngester", "Arn" ]
+              "Fn::GetAtt" : [ "HumioCloudWatchLogsIngester", "Arn" ]
             },
-            "humio_subscription_prefix" : { "Ref" : "HumioSubscriptionPrefix" },
-            "humio_subscription_backfiller" : { "Ref" : "HumioSubscriptionBackfiller" }
+            "humio_subscription_prefix" : { "Ref" : "HumioCloudWatchLogsSubscriptionPrefix" },
+            "humio_subscription_backfiller" : { "Ref" : "HumioCloudWatchLogsBackfillerSubscription" }
           }
         },
-        "Description" : "CloudWatch Logs to Humio log group auto subscriber.",
-        "Handler" : "auto_subscriber.lambda_handler",
+        "Description" : "CloudWatch Logs to Humio log group subscriber.",
+        "Handler" : "logs_subscriber.lambda_handler",
         "MemorySize" : "128",
         "Role" : {
-          "Fn::GetAtt" : [ "HumioLoggingRole", "Arn" ]
+          "Fn::GetAtt" : [ "HumioCloudWatchRole", "Arn" ]
         },
         "Runtime" : "python3.8",
         "Timeout" : "300"
       }
     },
-    "HumioAutoSubscriptionPermission" : {
-      "Condition" : "CreateAutoSubscriptionResources",
+    "HumioCloudWatchLogsSubscriberPermission" : {
+      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
       "Type" : "AWS::Lambda::Permission",
       "Properties" : {
         "Action" : "lambda:InvokeFunction",
         "FunctionName" : {
-          "Fn::GetAtt" : [ "HumioCloudwatchAutoSubscriber", "Arn" ]
+          "Fn::GetAtt" : [ "HumioCloudWatchLogsSubscriber", "Arn" ]
         },
         "Principal" : "events.amazonaws.com",
         "SourceAccount" : { "Ref" : "AWS::AccountId" }
       }
     },
-    "HumioAutoSubscriptionPermission2" : {
-      "Condition" : "CreateAutoSubscriptionResources",
+    "HumioCloudWatchLogsSubscriberPermission2" : {
+      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
       "Type" : "AWS::Lambda::Permission",
       "Properties" : {
         "Action" : "lambda:InvokeFunction",
         "FunctionName" : {
-          "Fn::GetAtt" : [ "HumioCloudwatchAutoSubscriber", "Arn" ]
+          "Fn::GetAtt" : [ "HumioCloudWatchLogsSubscriber", "Arn" ]
         },
         "Principal" : "events.amazonaws.com",
         "SourceArn" : {
-          "Fn::GetAtt" : [ "HumioAutoSubscriptionEventRule", "Arn" ]
+          "Fn::GetAtt" : [ "HumioCloudWatchLogsSubscriberEventRule", "Arn" ]
         }
       }
     },
-    "HumioCloudwatchBackfiller" : {
-      "DependsOn" : [ "HumioLoggingRole" ],
+    "HumioCloudWatchLogsBackfiller" : {
+      "DependsOn" : [ "HumioCloudWatchRole" ],
       "Type" : "AWS::Lambda::Function",
       "Properties" : {
         "Code" : {
@@ -206,42 +202,42 @@
           },
           "S3Key" : "cloudwatch_humio.zip"
         },
+
         "Environment" : {
           "Variables" : {
             "humio_log_ingester_arn" : {
-              "Fn::GetAtt" : [ "HumioCloudwatchIngester", "Arn" ]
+              "Fn::GetAtt" : [ "HumioCloudWatchLogsIngester", "Arn" ]
             },
-            "humio_subscription_prefix" : { "Ref": "HumioSubscriptionPrefix" },
-            "humio_repository_name" : { "Ref" : "HumioRepositoryName" },
+            "humio_subscription_prefix" : { "Ref": "HumioCloudWatchLogsSubscriptionPrefix" },
             "humio_protocol" : { "Ref" : "HumioProtocol" },
             "humio_host" : { "Ref" : "HumioHost" },
             "humio_ingest_token" : { "Ref" : "HumioIngestToken" },
-            "humio_subscription_enable" : { "Ref" : "HumioAutoSubscription" }
+            "humio_subscription_enable" : { "Ref" : "HumioCloudWatchLogsAutoSubscription" }
           }
         },
-        "Description" : "CloudWatch Logs to Humio backfiller.",
-        "Handler" : "backfiller.lambda_handler",
+        "Description" : "CloudWatch Logs to Humio logs backfiller.",
+        "Handler" : "logs_backfiller.lambda_handler",
         "MemorySize" : "128",
         "Role" : {
-          "Fn::GetAtt" : [ "HumioLoggingRole", "Arn" ]
+          "Fn::GetAtt" : [ "HumioCloudWatchRole", "Arn" ]
         },
         "Runtime" : "python3.8",
         "Timeout" : "300"
       }
     },
-    "HumioCloudwatchBackfillerPermission" : {
+    "HumioCloudWatchLogsBackfillerPermission" : {
       "Type" : "AWS::Lambda::Permission",
       "Properties" : {
         "Action" : "lambda:InvokeFunction",
         "FunctionName" : {
-          "Fn::GetAtt" : [ "HumioCloudwatchBackfiller", "Arn" ]
+          "Fn::GetAtt" : [ "HumioCloudWatchLogsBackfiller", "Arn" ]
         },
         "Principal" : "logs.amazonaws.com"
       }
     },
-    "HumioAutoSubscriptionS3Bucket" : {
+    "HumioCloudWatchLogsSubscriberS3Bucket" : {
       "Type" : "AWS::S3::Bucket",
-      "Condition" : "CreateAutoSubscriptionResources",
+      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
       "Properties" : {
         "AccessControl" : "BucketOwnerFullControl",
         "BucketName" : {
@@ -249,12 +245,12 @@
         }
       }
     },
-    "HumioAutoSubscriptionS3BucketPolicy" : {
+    "HumioCloudWatchLogsSubscriberS3BucketPolicy" : {
       "Type" : "AWS::S3::BucketPolicy",
-      "DependsOn" : [ "HumioAutoSubscriptionS3Bucket" ],
-      "Condition" : "CreateAutoSubscriptionResources",
+      "DependsOn" : [ "HumioCloudWatchLogsSubscriberS3Bucket" ],
+      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
       "Properties" : {
-        "Bucket" : { "Ref" : "HumioAutoSubscriptionS3Bucket" },
+        "Bucket" : { "Ref" : "HumioCloudWatchLogsSubscriberS3Bucket" },
         "PolicyDocument" : {
           "Version" : "2012-10-17",
           "Statement" : [
@@ -266,7 +262,7 @@
               },
               "Action" : "s3:GetBucketAcl",
               "Resource" : {
-                "Fn::GetAtt" : [ "HumioAutoSubscriptionS3Bucket", "Arn" ]
+                "Fn::GetAtt" : [ "HumioCloudWatchLogsSubscriberS3Bucket", "Arn" ]
               }
             },
             {
@@ -277,7 +273,7 @@
               },
               "Action" : "s3:PutObject",
               "Resource" : {
-                "Fn::Join" : [ "", [ { "Fn::GetAtt" : [ "HumioAutoSubscriptionS3Bucket", "Arn" ] }, "/AWSLogs/", { "Ref" : "AWS::AccountId" }, "/*" ] ]
+                "Fn::Join" : [ "", [ { "Fn::GetAtt" : [ "HumioCloudWatchLogsSubscriberS3Bucket", "Arn" ] }, "/AWSLogs/", { "Ref" : "AWS::AccountId" }, "/*" ] ]
               },
               "Condition" : {
                 "StringEquals" : { "s3:x-amz-acl" : "bucket-owner-full-control" }
@@ -287,10 +283,10 @@
         }
       }
     },
-    "HumioAutoSubscriptionCloudTrail" : {
+    "HumioCloudWatchLogsSubscriberCloudTrail" : {
       "Type" : "AWS::CloudTrail::Trail",
-      "DependsOn" : [ "HumioAutoSubscriptionS3BucketPolicy" ],
-      "Condition" : "CreateAutoSubscriptionResources",
+      "DependsOn" : [ "HumioCloudWatchLogsSubscriberS3BucketPolicy" ],
+      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
       "Properties" : {
         "EnableLogFileValidation" : false,
         "IncludeGlobalServiceEvents" : true,
@@ -304,10 +300,10 @@
         }
       }
     },
-    "HumioAutoSubscriptionEventRule" : {
+    "HumioCloudWatchLogsSubscriberEventRule" : {
       "Type" : "AWS::Events::Rule",
-      "DependsOn" : [ "HumioCloudwatchAutoSubscriber" ],
-      "Condition" : "CreateAutoSubscriptionResources",
+      "DependsOn" : [ "HumioCloudWatchLogsSubscriber" ],
+      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
       "Properties" : {
         "Description" : "Humio log group auto subscription event rule.",
         "EventPattern" : {
@@ -327,10 +323,86 @@
               "Fn::Join" : [ "", [ "humio-auto-subscription-", { "Ref" : "AWS::StackName" } ] ]
             },
             "Arn" : {
-              "Fn::GetAtt" : [ "HumioCloudwatchAutoSubscriber", "Arn" ]
+              "Fn::GetAtt" : [ "HumioCloudWatchLogsSubscriber", "Arn" ]
             }
           }
         ]
+      }
+    },
+    "HumioCloudWatchMetricIngester" : {
+      "DependsOn" : [ "HumioCloudWatchRole" ],
+      "Type" : "AWS::Lambda::Function",
+      "Properties" : {
+        "Code" : {
+          "S3Bucket" : { 
+            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ] 
+          },
+          "S3Key" : "cloudwatch_humio.zip"
+        },
+
+        "Environment" : {
+          "Variables" : {
+            "humio_protocol" : { "Ref" : "HumioProtocol" },
+            "humio_host" : { "Ref" : "HumioHost" },
+            "humio_ingest_token" : { "Ref" : "HumioIngestToken" }
+          }
+        },
+        "Description" : "CloudWatch metrics to Humio ingester.",
+        "Handler" : "metric_ingester.lambda_handler",
+        "MemorySize" : "128",
+        "Role" : {
+          "Fn::GetAtt" : [ "HumioCloudWatchRole", "Arn" ]
+        },
+        "Runtime" : "python3.8",
+        "Timeout" : "300"
+      }
+    },
+    "HumioCloudWatchMetricIngesterPermission" : {
+      "Type" : "AWS::Lambda::Permission",
+      "Properties" : {
+        "Action" : "lambda:InvokeFunction",
+        "FunctionName" : {
+          "Fn::GetAtt" : [ "HumioCloudWatchMetricIngester", "Arn" ]
+        },
+        "Principal" : "logs.amazonaws.com"
+      }
+    },
+    "HumioCloudWatchMetricStatisticsIngester" : {
+      "DependsOn" : [ "HumioCloudWatchRole" ],
+      "Type" : "AWS::Lambda::Function",
+      "Properties" : {
+        "Code" : {
+          "S3Bucket" : { 
+            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ] 
+          },
+          "S3Key" : "cloudwatch_humio.zip"
+        },
+
+        "Environment" : {
+          "Variables" : {
+            "humio_protocol" : { "Ref" : "HumioProtocol" },
+            "humio_host" : { "Ref" : "HumioHost" },
+            "humio_ingest_token" : { "Ref" : "HumioIngestToken" }
+          }
+        },
+        "Description" : "CloudWatch metrics statistics to Humio ingester.",
+        "Handler" : "metric_statistics_ingester.lambda_handler",
+        "MemorySize" : "128",
+        "Role" : {
+          "Fn::GetAtt" : [ "HumioCloudWatchRole", "Arn" ]
+        },
+        "Runtime" : "python3.8",
+        "Timeout" : "300"
+      }
+    },
+    "HumioCloudWatchMetricStatisticsIngesterPermission" : {
+      "Type" : "AWS::Lambda::Permission",
+      "Properties" : {
+        "Action" : "lambda:InvokeFunction",
+        "FunctionName" : {
+          "Fn::GetAtt" : [ "HumioCloudWatchMetricStatisticsIngester", "Arn" ]
+        },
+        "Principal" : "logs.amazonaws.com"
       }
     }
   }

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,10 +2,12 @@
 set -e
 cat cloudformation.json | jq
 make build
-aws s3 cp --acl public-read cloudformation.json s3://humio-public-us-east-1/
 
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-eu-central-1/
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-eu-west-1/
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-east-1/
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-east-2/
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-west-2/
+aws s3 cp --acl public-read cloudformation.json s3://humio-public-us-east-1/ --profile cloudwatch --region us-east-1
+
+aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-eu-central-1/ --profile cloudwatch --region eu-central-1
+aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-eu-west-1/ --profile cloudwatch --region eu-west-1
+aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-east-1/ --profile cloudwatch --region us-east-1
+aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-east-2/ --profile cloudwatch --region us-east-2
+aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-west-2/ --profile cloudwatch --region us-west-2
+ 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/src/logs_backfiller.py
+++ b/src/logs_backfiller.py
@@ -19,11 +19,10 @@ def lambda_handler(event, context):
     :param event: Event data from CloudWatch Logs.
     :type event: dict
 
-    :param context: Lambda object context.
+    :param context: Lambda context object.
     :type context: obj
 
     :return: None
-    :rtype: NoneType
     """
     # Grab all log groups with a token and/or prefix if we have them.
     if "nextToken" in event.keys():
@@ -46,10 +45,9 @@ def lambda_handler(event, context):
             log_groups = log_client.describe_log_groups()
 
     # If we have a next token, recursively fire another instance of backfiller with it.
-    # This is to look through all events.
-    if 'nextToken' in log_groups.keys():
+    if "nextToken" in log_groups.keys():
         lambda_client = boto3.client("lambda")
-        event['nextToken'] = log_groups['nextToken']
+        event["nextToken"] = log_groups["nextToken"]
         lambda_client.invoke(
             FunctionName=context.function_name,
             InvocationType="Event",
@@ -80,7 +78,7 @@ def lambda_handler(event, context):
                 )
             # We are now subscribed.
             else:
-                print("We are already subscribed to %s" % log_group['logGroupName'])
+                print("We are already subscribed to %s" % log_group["logGroupName"])
         # When there are no subscription filters, let us subscribe!
         else:
             helpers.create_subscription(

--- a/src/logs_subscriber.py
+++ b/src/logs_subscriber.py
@@ -12,16 +12,15 @@ log_client = boto3.client("logs")
 
 def lambda_handler(event, context):
     """
-    Auto-subscribe to log group from event.
+    Subscribes log ingester to log group from event.
 
     :param event: Event data from CloudWatch Logs.
     :type event: dict
 
-    :param context: Lambda object context.
+    :param context: Lambda context object.
     :type context: obj
 
     :return: None
-    :rtype: NoneType
     """
     # Grab the log group name from incoming event.
     log_group_name = event["detail"]["requestParameters"]["logGroupName"]

--- a/src/metric_ingester.py
+++ b/src/metric_ingester.py
@@ -1,0 +1,134 @@
+import boto3
+import json
+import helpers
+from datetime import datetime, timedelta, timezone
+
+_is_setup = False
+
+
+def lambda_handler(event, context):
+    """
+    Ingest CloudWatch Metrics data to Humio repository.
+
+    :param event: Event data.
+    :type event: dict
+
+    :param context: Lambda context object.
+    :type context: obj
+
+    :return: None
+    """
+    # Persist variables across lambda invocations.
+    if not _is_setup:
+        helpers.setup()
+
+    # Load user defined configurations for the API request. 
+    user_defined_data = json.load(open("user_defined_metric_data.json", "r"))
+
+    # Set next token if one is present in the event.
+    if "NextToken" in event.keys():
+        user_defined_data["NextToken"] = event["NextToken"]
+
+    # Set default start time if none is present.
+    if "StartTime" not in user_defined_data.keys():
+        if "StartTime" in event.keys():
+            user_defined_data["StartTime"] = event["StartTime"]
+        else:
+            user_defined_data["StartTime"] = (datetime.utcnow() - timedelta(minutes=15))\
+                .replace(tzinfo=timezone.utc).isoformat()  # 15 minutes ago.
+    
+    # Set default end time if none is present. 
+    if "EndTime" not in user_defined_data.keys():
+        if "EndTime" in event.keys():
+            user_defined_data["EndTime"] = event["EndTime"]
+        else:
+            user_defined_data["EndTime"] = datetime.utcnow()\
+                .replace(tzinfo=timezone.utc).isoformat()  # Now.
+            
+    # Make CloudWatch:GetMetricData API request.
+    metric_data = get_metric_data(user_defined_data)
+
+    # If there is a next token in the metric data,
+    # then use this to retrieve the rest of the metrics recursively.
+    if "NextToken" in metric_data:
+        lambda_client = boto3.client("lambda")
+        # Pass on next token, start time, and end time.
+        event["NextToken"] = metric_data["NextToken"]
+        event["StartTime"] = user_defined_data["StartTime"]
+        event["EndTime"] = user_defined_data["EndTime"]
+        lambda_client.invoke(
+            FunctionName=context.function_name,
+            InvocationType="Event",
+            Payload=json.dumps(event)
+        )
+
+    # Format metric data to Humio event data.
+    humio_events = create_humio_events(metric_data, user_defined_data)
+
+    # Send Humio event data to Humio.
+    request = helpers.ingest_events(humio_events, "cloudwatch_metrics")
+
+    # Debug the response.
+    response = request.text
+    print("Got response %s from Humio." % response)
+
+
+def get_metric_data(user_defined_data):
+    """
+    Make CloudWatch:GetMetricData API request.
+
+    :param user_defined_data: User defined API request parameters for the boto client.
+    :type user_defined_data: list
+
+    :return: Metric data retrieved from request.
+    :rtype: dict
+    """
+    # Create CloudWatch client.
+    metric_client = boto3.client("cloudwatch")
+
+    # Make GetMetricData API request.
+    metric_data = metric_client.get_metric_data(
+        **user_defined_data
+    )
+    return metric_data
+
+
+def create_humio_events(metrics, user_defined_data):
+    """
+    Create list of Humio events based on metrics.
+
+    :param metrics: Metrics received from GetMetricData.
+    :type metrics: dict
+
+    :param user_defined_data: User defined API request parameters for the boto client.
+    :type user_defined_data: dict
+
+    :return: Events to be sent to Humio.
+    :rtype: list
+    """
+    humio_events = []
+
+    # Create Humio event based on each extracted timestamp. 
+    for result in metrics["MetricDataResults"]:
+        count = 0
+        for timestamp in result["Timestamps"]:
+            timestamp = timestamp.replace(tzinfo=timezone.utc).isoformat()
+            event = {
+                "timestamp": timestamp,
+                "attributes": {
+                    "metricDataResults": {
+                        "id": result["Id"],
+                        "label": result["Label"],
+                        "value": result["Values"][count],
+                        "status_code": result["StatusCode"],
+                        "messsage": result.get("Messages"[count], "None")
+                    },
+                    "messages": metrics.get("Messages", "None"),
+                    "requestType": "GetMetricData",
+                    "userDefinedData": user_defined_data
+                }
+            }
+            humio_events.append(event)
+            count += 1
+
+    return humio_events

--- a/src/metric_statistics_ingester.py
+++ b/src/metric_statistics_ingester.py
@@ -1,0 +1,123 @@
+import boto3
+import json
+import helpers
+from datetime import datetime, timedelta, timezone
+
+_is_setup = False
+
+
+def lambda_handler(event, context):
+    """
+    Ingest CloudWatch Metric statistics to Humio repository.
+
+    :param event: Event data.
+    :type event: dict
+
+    :param context: Lambda context object.
+    :type context: obj
+
+    :return: None
+    """
+    # Persist variables across lambda invocations.
+    if not _is_setup:
+        helpers.setup()
+
+    # Load user defined configurations for the API request. 
+    user_defined_data = json.load(open("user_defined_metric_data.json", "r"))
+
+    # Make CloudWatch:GetMetricStatistics API request.
+    metric_statistics, api_parameters = get_metric_statistics(user_defined_data)
+
+    # Used for debugging.
+    print("Statistics from CloudWatch Metrics: %s" % metric_statistics)
+
+    # Format metric data to Humio event data.
+    humio_events = create_humio_events(metric_statistics, api_parameters)
+
+    # Send Humio event data to Humio.
+    request = helpers.ingest_events(humio_events, "cloudwatch_metrics")
+
+    # Debug the response.
+    response = request.text
+    print("Got response %s from Humio." % response)
+
+
+def get_metric_statistics(user_defined_data):
+    """
+    Make CloudWatch:GetMetricStatistics API request.
+
+    :param user_defined_data: User defined API request parameters for the boto client.
+    This is a list of one or more API parameters to make one or more calls.
+    :type user_defined_data: list
+
+    :return: Metric statistics retrieved from a request and the corresponding API parameters.
+    :rtype: dict, dict
+    """
+    # Create CloudWatch client.
+    metric_client = boto3.client("cloudwatch")
+
+    # Make CloudWatch:GetMetricStatistics API request.
+    for api_parameters in user_defined_data:
+
+        # Check whether start and end time has been set or defaults are to be used.
+        if "StartTime" not in api_parameters.keys():
+            api_parameters["StartTime"] = datetime.utcnow() - timedelta(minutes=15)  # 15 minutes ago.
+            api_parameters["StartTime"] = api_parameters["StartTime"].replace(tzinfo=timezone.utc).isoformat()
+
+        if "EndTime" not in api_parameters.keys():
+            api_parameters["EndTime"] = datetime.utcnow()  # Now.
+            api_parameters["EndTime"] = api_parameters["EndTime"].replace(tzinfo=timezone.utc).isoformat()
+
+        # Used for debugging.
+        print("Start time: %s, End time: %s" % (api_parameters["StartTime"], api_parameters["EndTime"]))
+
+        # Make GetMetricStatistics API request.
+        metric_statistics = metric_client.get_metric_statistics(
+            **api_parameters
+        )
+        return metric_statistics, api_parameters
+
+
+def create_humio_events(metrics, api_parameters):
+    """
+    Create list of Humio events based on metrics.
+
+    :param metrics: Metrics received from GetMetricStatistics.
+    :type metrics: dict
+
+    :param lambda_event: API parameters used for the API request 
+    to retrieve the metric statistics.
+    :type lambda_event: dict
+
+    :return: List of events to be sent to Humio.
+    :rtype: list
+    """
+    humio_events = []
+
+    # Used for debuggin.
+    print("Datapoints: %s" % metrics["Datapoints"])
+
+    # Create one Humio event per datapoint/timestamp.
+    for datapoint in metrics["Datapoints"]:
+        # Create event data.
+        event = {
+            "timestamp": datapoint["Timestamp"].replace(tzinfo=timezone.utc).isoformat(),
+            "attributes": {
+                "label": metrics["Label"],
+                "datapoint": {
+                    "sampleCount": datapoint.get("Samplecount", "None"),
+                    "average": datapoint.get("Average", "None"),
+                    "sum": datapoint.get("Sum", "None"),
+                    "minimum": datapoint.get("Minimum", "None"),
+                    "maximum": datapoint.get("Maximum", "None"),
+                    "unit": datapoint["Unit"],
+                    "extendedStatistics": datapoint.get("ExtendedStatistics", "None"),
+                    "responseMetaData": metrics["ResponseMetadata"]
+                },
+                "requestType": "GetMetricStatistics",
+                "userDefinedData ": api_parameters
+            }
+        }
+        humio_events.append(event)
+
+    return humio_events

--- a/src/user_defined_metric_data.json
+++ b/src/user_defined_metric_data.json
@@ -1,0 +1,16 @@
+{
+    "MetricDataQueries": [
+        {
+            "Id": "test_cloudwatch_metrics_lambda_invocations",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": "AWS/Lambda",
+                    "MetricName": "Invocations" 
+                },
+                "Period": 60,
+                "Stat": "Sum",
+                "Unit": "Count"
+            }
+        }
+    ]
+}

--- a/src/user_defined_metric_statistics_data.json
+++ b/src/user_defined_metric_statistics_data.json
@@ -1,0 +1,18 @@
+[
+    {
+      "Namespace": "AWS/Lambda",
+      "MetricName": "Invocations",
+      "Period": 60,
+      "Statistics": [
+        "Sum"
+      ]
+    },
+    {
+      "Namespace": "AWS/Lambda",
+      "MetricName": "Errors",
+      "Period": 60,
+      "Statistics": [
+        "Sum"
+      ]
+    }
+]


### PR DESCRIPTION
The integration now supports ingesting metrics from CloudWatch. 
The ReadMe has been updated to describe how to set up the project manually from GitHub.
The code structure has been refactored and cleaned up. 