### PR TITLE
Issue/3/make backfiller start automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
-
 # Changelog
 
-## (2020-07-12)
-CloudFormation update to support an AWS VPC.
+## (2020-07-13)
+CloudFormation update to support using an AWS VPC for lambda ingesters and for the backfiller to be able to run automatically.
+
+### Added
+- Support for using a VPC regarding lambda ingesters based on a conditional. 
+- Support for automatically running the backfiller lambda on create using a sns topic based on a conditional.
 
 ### Changed
-- CloudFormation file to support a VPC based on a conditional. 
+- Parameter and resource names in the CloudFormation file.
+
+### Removed
+- Unused environment variables in the CloudFormation file.
 
 ## (2020-06-11)
 Major refactoring of codebase and new feature for retrieving CloudWatch metrics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,16 @@
 CloudFormation updated to support using an AWS VPC for lambda ingesters and for the backfiller to be able to be run automatically when created.
 
 ### Added
-- Support for using a VPC regarding lambda ingesters based on a conditional. 
-- Support for automatically running the backfiller lambda on create using a sns topic based on a conditional.
+- Support for using a VPC regarding lambda ingesters based on a conditional set. 
+- Support for automatically running the backfiller lambda when created based on a conditional set.
 
 ### Changed
 - Parameter and resource names in the CloudFormation file.
+- Formatting.
 
 ### Removed
 - Unused environment variables in the CloudFormation file.
+- Unused library.
 
 ## (2020-06-11)
 Major refactoring of codebase and new feature for retrieving CloudWatch metrics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## (2020-07-12)
+CloudFormation update to support an AWS VPC.
+
+### Changed
+- CloudFormation file to support a VPC based on a conditional. 
+
 ## (2020-06-11)
 Major refactoring of codebase and new feature for retrieving CloudWatch metrics.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## (2020-07-13)
-CloudFormation update to support using an AWS VPC for lambda ingesters and for the backfiller to be able to run automatically.
+CloudFormation updated to support using an AWS VPC for lambda ingesters and for the backfiller to be able to be run automatically when created.
 
 ### Added
 - Support for using a VPC regarding lambda ingesters based on a conditional. 

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -39,7 +39,7 @@
         "false"
       ],
       "Description" : "Make the backfiller run automatically when created. Set to 'true' to enable.",
-      "Default" : "false"
+      "Default" : "true"
     },
     "EnableVPCForIngesterLambdas" : {
       "Type" : "String",
@@ -71,15 +71,6 @@
     }
   },
   "Resources" : {
-    "HumioBackfillerAutoRunner" : {
-      "Condition" : "CreateHumioBackfillerAutoRunner",
-      "DependsOn" : [ "HumioCloudWatchLogsBackfiller" ],
-      "Type" : "Custom::BackfillerAutoRunner",
-      "Properties" : {
-        "ServiceToken" : { "Fn::GetAtt" : [ "HumioCloudWatchLogsBackfiller", "Arn" ] },
-        "StackName" : { "Ref" : "AWS::StackName" }
-      }
-    },
     "HumioCloudWatchRole" : {
       "Type" : "AWS::IAM::Role",
       "Properties" : {
@@ -272,7 +263,9 @@
       "Type" : "AWS::Lambda::Function",
       "Properties" : {
         "Code" : {
-          "S3Bucket" : "humio-cloudformation-test",
+          "S3Bucket" : {
+            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+          },
           "S3Key" : "cloudwatch_humio.zip"
         },
         "Environment" : {
@@ -304,6 +297,15 @@
           "Fn::GetAtt" : [ "HumioCloudWatchLogsBackfiller", "Arn" ]
         },
         "Principal" : "logs.amazonaws.com"
+      }
+    },
+    "HumioBackfillerAutoRunner" : {
+      "Condition" : "CreateHumioBackfillerAutoRunner",
+      "DependsOn" : [ "HumioCloudWatchLogsBackfiller" ],
+      "Type" : "Custom::BackfillerAutoRunner",
+      "Properties" : {
+        "ServiceToken" : { "Fn::GetAtt" : [ "HumioCloudWatchLogsBackfiller", "Arn" ] },
+        "StackName" : { "Ref" : "AWS::StackName" }
       }
     },
     "HumioCloudWatchLogsSubscriberS3Bucket" : {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -41,10 +41,6 @@
       "Description" : "Make the backfiller run automatically when created. Set to 'true' to enable.",
       "Default" : "false"
     },
-    "SNSTopicArn" : {
-      "Type" : "String",
-      "Description" : "SNS Topic Arn to be used with the backfiller to make it run automatically when created. Only required if backfiller autorun is enabled."
-    },
     "EnableVPCForIngesterLambdas" : {
       "Type" : "String",
       "AllowedValues" : [
@@ -67,7 +63,7 @@
     "CreateAutoSubscriptionResources" : {
       "Fn::Equals" : [ { "Ref" : "EnableCloudWatchLogsAutoSubscription" }, "true" ]
     },
-    "SubscribeBackfillerToSNSTopic" : {
+    "CreateHumioBackfillerAutoRunner" : {
       "Fn::Equals" : [ { "Ref" : "EnableCloudWatchLogsBackfillerAutoRun" }, "true" ]     
     },
     "ConfigureVPCForIngesterLambdas" : {
@@ -75,6 +71,15 @@
     }
   },
   "Resources" : {
+    "HumioBackfillerAutoRunner" : {
+      "Condition" : "CreateHumioBackfillerAutoRunner",
+      "DependsOn" : [ "HumioCloudWatchLogsBackfiller" ],
+      "Type" : "Custom::BackfillerAutoRunner",
+      "Properties" : {
+        "ServiceToken" : { "Fn::GetAtt" : [ "HumioCloudWatchLogsBackfiller", "Arn" ] },
+        "StackName" : { "Ref" : "AWS::StackName" }
+      }
+    },
     "HumioCloudWatchRole" : {
       "Type" : "AWS::IAM::Role",
       "Properties" : {
@@ -267,9 +272,7 @@
       "Type" : "AWS::Lambda::Function",
       "Properties" : {
         "Code" : {
-          "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
-          },
+          "S3Bucket" : "humio-cloudformation-test",
           "S3Key" : "cloudwatch_humio.zip"
         },
         "Environment" : {
@@ -302,29 +305,6 @@
         },
         "Principal" : "logs.amazonaws.com"
       }
-    },
-    "HumioCloudWatchLogsBackfillerPermission2" : {
-      "Condition" : "SubscribeBackfillerToSNSTopic",
-      "Type" : "AWS::Lambda::Permission",
-      "Properties" : {
-        "Action" : "lambda:InvokeFunction",
-        "FunctionName" : {
-          "Fn::GetAtt" : [ "HumioCloudWatchLogsBackfiller", "Arn" ]
-        },
-        "Principal" : "sns.amazonaws.com"
-      }
-    },
-    "HumioCloudWatchLogsBackfillerSNSSubscription" : {
-      "Condition" : "SubscribeBackfillerToSNSTopic",
-      "DependsOn" : [ "HumioCloudWatchLogsBackfiller" ],
-      "Type" : "AWS::SNS::Subscription",
-      "Properties" : {
-        "Endpoint" : {
-          "Fn::GetAtt" : [ "HumioCloudWatchLogsBackfiller", "Arn" ]
-        },
-        "Protocol" : "lambda",
-        "TopicArn" : { "Ref" : "SNSTopicArn" }
-      } 
     },
     "HumioCloudWatchLogsSubscriberS3Bucket" : {
       "Condition" : "CreateAutoSubscriptionResources",

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -14,7 +14,7 @@
     },
     "HumioIngestToken" : {
       "Type" : "String",
-      "Description" : "The value of the ingest token for the repository to ship log/metric events to from your Humio account.",
+      "Description" : "The value of the ingest token for the repository from your Humio account to ship log/metric events to.",
       "Default" : "",
       "NoEcho" : true
     },
@@ -56,11 +56,11 @@
     },
     "SecurityGroupIds" : {
       "Type" : "CommaDelimitedList",
-      "Description" : "A list of security group ids for the VPC configuration for the ingester lambda functions. Only required if VPC is enabled."
+      "Description" : "A comma separated list of security group ids for the VPC configuration regarding the ingester lambda functions. Only required if VPC is enabled."
     },
     "SubnetIds" : {
       "Type" : "CommaDelimitedList",
-      "Description" : "A list of subnet ids used by the VPC configuration that the ingester lamda functions will be deployed into. Only required if VPC is enabled."
+      "Description" : "A comma separated list of subnet ids used by the VPC configuration that the ingester lamda functions will be deployed into. Only required if VPC is enabled."
     }
   },
   "Conditions" : {
@@ -375,9 +375,9 @@
       }
     },
     "HumioCloudWatchLogsSubscriberCloudTrail" : {
-      "Type" : "AWS::CloudTrail::Trail",
-      "DependsOn" : [ "HumioCloudWatchLogsSubscriberS3BucketPolicy" ],
       "Condition" : "CreateAutoSubscriptionResources",
+      "DependsOn" : [ "HumioCloudWatchLogsSubscriberS3BucketPolicy" ],
+      "Type" : "AWS::CloudTrail::Trail",
       "Properties" : {
         "EnableLogFileValidation" : false,
         "IncludeGlobalServiceEvents" : true,
@@ -392,9 +392,9 @@
       }
     },
     "HumioCloudWatchLogsSubscriberEventRule" : {
-      "Type" : "AWS::Events::Rule",
-      "DependsOn" : [ "HumioCloudWatchLogsSubscriber" ],
       "Condition" : "CreateAutoSubscriptionResources",
+      "DependsOn" : [ "HumioCloudWatchLogsSubscriber" ],
+      "Type" : "AWS::Events::Rule",
       "Properties" : {
         "Description" : "Humio log group auto subscription event rule.",
         "EventPattern" : {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -1,24 +1,7 @@
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
-  "Description": "CloudWatch to Humio Integration for sending CloudWatch Logs and Metrics to Humio.",
+  "Description" : "CloudWatch to Humio Integration for sending CloudWatch Logs and Metrics to Humio.",
   "Parameters" : {
-    "ConfigureIngestLambdaVpcConfig": {
-      "Type": "String",
-      "AllowedValues" : [
-        "true",
-        "false"
-      ],
-      "Description": "Enabling this will allow you to use a VPC for the lambda ingester functions.",
-      "Default": "false"
-    },
-    "SecurityGroupIds" : {
-      "Type": "CommaDelimitedList",
-      "Description": "A list of security group ids for the VPC configuration of the ingester lambda functions."
-    },
-    "SubnetIds" : {
-      "Type": "CommaDelimitedList",
-      "Description": "A list of subnet ids that the ingester lamda functions will be deployed into."
-    },
     "HumioProtocol" : {
       "Type" : "String",
       "Description" : "The transport protocol used for delivering log/metric events to Humio. HTTPS is default and recommended.",
@@ -26,36 +9,69 @@
     },
     "HumioHost" : {
       "Type" : "String",
-      "Description" : "The host to ship Humio logs/metrics to.",
+      "Description" : "The host to ship Humio log/metric events to.",
       "Default" : "cloud.humio.com"
     },
     "HumioIngestToken" : {
       "Type" : "String",
-      "Description" : "The value of the ingest token for the repository to ship logs/metrics to from your Humio account.",
+      "Description" : "The value of the ingest token for the repository to ship log/metric events to from your Humio account.",
       "Default" : "",
       "NoEcho" : true
     },
-    "HumioCloudWatchLogsAutoSubscription" : {
+    "EnableCloudWatchLogsAutoSubscription" : {
       "Type" : "String",
       "AllowedValues" : [
         "true",
         "false"
       ],
-      "Default" : "true",
-      "Description" : "Enabling this will make the logs ingester automatically subscribe to new log groups specified with the prefix below. Set to 'true' to enable."
+      "Description" : "Make the log ingester automatically subscribe to new log groups specified with the logs subscription prefix parameter. Set to 'true' to enable.",
+      "Default" : "true"
     },
     "HumioCloudWatchLogsSubscriptionPrefix" : {
       "Type" : "String",
       "Description" : "Humio will only subscribe to log groups with the prefix specified.",
       "Default" : ""
+    },
+    "EnableCloudWatchLogsBackfillerAutoRun" : {
+      "Type" : "String", 
+      "AllowedValues" : [
+        "true",
+        "false"
+      ],
+      "Description" : "Make the backfiller run automatically when created. Set to 'true' to enable.",
+      "Default" : "false"
+    },
+    "SNSTopicArn" : {
+      "Type" : "String",
+      "Description" : "SNS Topic Arn to be used with the backfiller to make it run automatically when created. Only required if backfiller autorun is enabled."
+    },
+    "EnableVPCForIngesterLambdas" : {
+      "Type" : "String",
+      "AllowedValues" : [
+        "true",
+        "false"
+      ],
+      "Description" : "Use a VPC for the lambda ingester functions. Set to 'true' to enable.",
+      "Default" : "false"
+    },
+    "SecurityGroupIds" : {
+      "Type" : "CommaDelimitedList",
+      "Description" : "A list of security group ids for the VPC configuration for the ingester lambda functions. Only required if VPC is enabled."
+    },
+    "SubnetIds" : {
+      "Type" : "CommaDelimitedList",
+      "Description" : "A list of subnet ids used by the VPC configuration that the ingester lamda functions will be deployed into. Only required if VPC is enabled."
     }
   },
   "Conditions" : {
-    "CreateHumioCloudWatchLogsAutoSubscriptionResources" : {
-      "Fn::Equals" : [ { "Ref" : "HumioCloudWatchLogsAutoSubscription" }, "true" ]
+    "CreateAutoSubscriptionResources" : {
+      "Fn::Equals" : [ { "Ref" : "EnableCloudWatchLogsAutoSubscription" }, "true" ]
     },
-    "ConfigureIngestLambdaVpcConfig" : {
-      "Fn::Equals" : [ { "Ref" : "ConfigureIngestLambdaVpcConfig" }, "true" ]
+    "SubscribeBackfillerToSNSTopic" : {
+      "Fn::Equals" : [ { "Ref" : "EnableCloudWatchLogsBackfillerAutoRun" }, "true" ]     
+    },
+    "ConfigureVPCForIngesterLambdas" : {
+      "Fn::Equals" : [ { "Ref" : "EnableVPCForIngesterLambdas" }, "true" ]
     }
   },
   "Resources" : {
@@ -83,7 +99,7 @@
           {
             "PolicyName" : "humio_cloudwatch_role",
             "PolicyDocument" : {
-              "Fn::If": ["ConfigureIngestLambdaVpcConfig",
+              "Fn::If" : [ "ConfigureVPCForIngesterLambdas",
                 {
                   "Version" : "2012-10-17",
                   "Statement" : [
@@ -158,18 +174,17 @@
           "Variables" : {
             "humio_protocol" : { "Ref" : "HumioProtocol" },
             "humio_host" : { "Ref" : "HumioHost" },
-            "humio_ingest_token" : { "Ref" : "HumioIngestToken" },
-            "humio_subscription_enable" : { "Ref" : "HumioCloudWatchLogsAutoSubscription" }
+            "humio_ingest_token" : { "Ref" : "HumioIngestToken" }
           }
         },
-        "VpcConfig": {
-          "Fn::If": ["ConfigureIngestLambdaVpcConfig",
+        "VpcConfig" : {
+          "Fn::If" : [ "ConfigureVPCForIngesterLambdas",
             {
-              "SecurityGroupIds": { "Ref": "SecurityGroupIds" },
-              "SubnetIds": { "Ref": "SubnetIds" }
+              "SecurityGroupIds" : { "Ref" : "SecurityGroupIds" },
+              "SubnetIds" : { "Ref" : "SubnetIds" }
             },
             {
-              "Ref": "AWS::NoValue"
+              "Ref" : "AWS::NoValue"
             }
           ]
         },
@@ -222,7 +237,7 @@
       }
     },
     "HumioCloudWatchLogsSubscriberPermission" : {
-      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
+      "Condition" : "CreateAutoSubscriptionResources",
       "Type" : "AWS::Lambda::Permission",
       "Properties" : {
         "Action" : "lambda:InvokeFunction",
@@ -234,7 +249,7 @@
       }
     },
     "HumioCloudWatchLogsSubscriberPermission2" : {
-      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
+      "Condition" : "CreateAutoSubscriptionResources",
       "Type" : "AWS::Lambda::Permission",
       "Properties" : {
         "Action" : "lambda:InvokeFunction",
@@ -257,17 +272,15 @@
           },
           "S3Key" : "cloudwatch_humio.zip"
         },
-
         "Environment" : {
           "Variables" : {
             "humio_log_ingester_arn" : {
               "Fn::GetAtt" : [ "HumioCloudWatchLogsIngester", "Arn" ]
             },
-            "humio_subscription_prefix" : { "Ref": "HumioCloudWatchLogsSubscriptionPrefix" },
+            "humio_subscription_prefix" : { "Ref" : "HumioCloudWatchLogsSubscriptionPrefix" },
             "humio_protocol" : { "Ref" : "HumioProtocol" },
             "humio_host" : { "Ref" : "HumioHost" },
-            "humio_ingest_token" : { "Ref" : "HumioIngestToken" },
-            "humio_subscription_enable" : { "Ref" : "HumioCloudWatchLogsAutoSubscription" }
+            "humio_ingest_token" : { "Ref" : "HumioIngestToken" }
           }
         },
         "Description" : "CloudWatch Logs to Humio logs backfiller.",
@@ -290,9 +303,32 @@
         "Principal" : "logs.amazonaws.com"
       }
     },
+    "HumioCloudWatchLogsBackfillerPermission2" : {
+      "Condition" : "SubscribeBackfillerToSNSTopic",
+      "Type" : "AWS::Lambda::Permission",
+      "Properties" : {
+        "Action" : "lambda:InvokeFunction",
+        "FunctionName" : {
+          "Fn::GetAtt" : [ "HumioCloudWatchLogsBackfiller", "Arn" ]
+        },
+        "Principal" : "sns.amazonaws.com"
+      }
+    },
+    "HumioCloudWatchLogsBackfillerSNSSubscription" : {
+      "Condition" : "SubscribeBackfillerToSNSTopic",
+      "DependsOn" : [ "HumioCloudWatchLogsBackfiller" ],
+      "Type" : "AWS::SNS::Subscription",
+      "Properties" : {
+        "Endpoint" : {
+          "Fn::GetAtt" : [ "HumioCloudWatchLogsBackfiller", "Arn" ]
+        },
+        "Protocol" : "lambda",
+        "TopicArn" : { "Ref" : "SNSTopicArn" }
+      } 
+    },
     "HumioCloudWatchLogsSubscriberS3Bucket" : {
+      "Condition" : "CreateAutoSubscriptionResources",
       "Type" : "AWS::S3::Bucket",
-      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
       "Properties" : {
         "AccessControl" : "BucketOwnerFullControl",
         "BucketName" : {
@@ -301,9 +337,9 @@
       }
     },
     "HumioCloudWatchLogsSubscriberS3BucketPolicy" : {
-      "Type" : "AWS::S3::BucketPolicy",
+      "Condition" : "CreateAutoSubscriptionResources",
       "DependsOn" : [ "HumioCloudWatchLogsSubscriberS3Bucket" ],
-      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
+      "Type" : "AWS::S3::BucketPolicy",
       "Properties" : {
         "Bucket" : { "Ref" : "HumioCloudWatchLogsSubscriberS3Bucket" },
         "PolicyDocument" : {
@@ -341,7 +377,7 @@
     "HumioCloudWatchLogsSubscriberCloudTrail" : {
       "Type" : "AWS::CloudTrail::Trail",
       "DependsOn" : [ "HumioCloudWatchLogsSubscriberS3BucketPolicy" ],
-      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
+      "Condition" : "CreateAutoSubscriptionResources",
       "Properties" : {
         "EnableLogFileValidation" : false,
         "IncludeGlobalServiceEvents" : true,
@@ -358,7 +394,7 @@
     "HumioCloudWatchLogsSubscriberEventRule" : {
       "Type" : "AWS::Events::Rule",
       "DependsOn" : [ "HumioCloudWatchLogsSubscriber" ],
-      "Condition" : "CreateHumioCloudWatchLogsAutoSubscriptionResources",
+      "Condition" : "CreateAutoSubscriptionResources",
       "Properties" : {
         "Description" : "Humio log group auto subscription event rule.",
         "EventPattern" : {
@@ -394,7 +430,6 @@
           },
           "S3Key" : "cloudwatch_humio.zip"
         },
-
         "Environment" : {
           "Variables" : {
             "humio_protocol" : { "Ref" : "HumioProtocol" },
@@ -402,14 +437,14 @@
             "humio_ingest_token" : { "Ref" : "HumioIngestToken" }
           }
         },
-        "VpcConfig": {
-          "Fn::If": ["ConfigureIngestLambdaVpcConfig",
+        "VpcConfig" : {
+          "Fn::If" : [ "ConfigureVPCForIngesterLambdas",
             {
-              "SecurityGroupIds": { "Ref": "SecurityGroupIds" },
-              "SubnetIds": { "Ref": "SubnetIds" }
+              "SecurityGroupIds" : { "Ref" : "SecurityGroupIds" },
+              "SubnetIds" : { "Ref" : "SubnetIds" }
             },
             {
-              "Ref": "AWS::NoValue"
+              "Ref" : "AWS::NoValue"
             }
           ]
         },
@@ -450,14 +485,14 @@
             "humio_ingest_token" : { "Ref" : "HumioIngestToken" }
           }
         },
-        "VpcConfig": {
-          "Fn::If": ["ConfigureIngestLambdaVpcConfig",
+        "VpcConfig" : {
+          "Fn::If" : [ "ConfigureVPCForIngesterLambdas",
             {
-              "SecurityGroupIds": { "Ref": "SecurityGroupIds" },
-              "SubnetIds": { "Ref": "SubnetIds" }
+              "SecurityGroupIds" : { "Ref" : "SecurityGroupIds" },
+              "SubnetIds" : { "Ref" : "SubnetIds" }
             },
             {
-              "Ref": "AWS::NoValue"
+              "Ref" : "AWS::NoValue"
             }
           ]
         },


### PR DESCRIPTION
- Updated CHANGELOG regarding the addition of the VPC configuration.
- Added support for starting the backfiller automatically during the stack creation, so that a manual execution is not necessary. (First, a SNS Topic was used, but it was found that using a custom resource was simpler regarding the setup, and would not require a user to create such a SNS Topic before the auto runner would work.)
- Updated the CHANGELOG regarding the addition of the automatically-start-the-backfiller feature. 
- Did some code reformatting and name changing in the CF file mostly. 