### PR TITLE
Versioning for a more seamless flow for updating the integration

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.0.0
 commit = True
 message = Bump version: {current_version} → {new_version}
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 0.0.0
+commit = True
+message = Bump version: {current_version} → {new_version}
+
+[bumpversion:file:Makefile]
+search = v{current_version}
+replace = v{new_version}
+
+[bumpversion:file:cloudformation.json]
+search = v{current_version}
+replace = v{new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.0
 commit = True
 message = Bump version: {current_version} → {new_version}
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.0
+current_version = 1.0.0
 commit = True
 message = Bump version: {current_version} → {new_version}
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.0
+current_version = 0.1.0
 commit = True
 message = Bump version: {current_version} → {new_version}
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -10,3 +10,7 @@ replace = v{new_version}
 [bumpversion:file:cloudformation.json]
 search = v{current_version}
 replace = v{new_version}
+
+[bumpversion:file:deploy.sh]
+search = v{current_version}
+replace = v{new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
 ## 1.0.0 (2020-09-08)
-Versioning added for a more seamless update-the-integration flow.
+Versioning added for a more seamless flow for updating the integration..
 
 ### Added
 - Support for updating an integration to its newest version.
 - Bump2version configuration file for maintaining the integration version.
 - Version parameter in the CloudFormation file.
-- Section for how to release a new version for maintainers. 
+- Section describing how to release a new version for maintainers. 
 
 ### Changed
 - Guide for setting up the integration for local development.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Versioning added for a more seamless update-the-integration flow.
 
 ### Added
 - Support for updating an integration to its newest version.
+- Bump2version configuration file for maintaining the integration version.
 - Version parameter in the CloudFormation file.
 - Section for how to release a new version for maintainers. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.0.0 (2020-09-08)
+Versioning added for a more seamless update-the-integration flow.
+
+### Added
+- Support for updating an integration to its newest version.
+- Version parameter in the CloudFormation file.
+- Section for how to release a new version for maintainers. 
+
+### Changed
+- Guide for setting up the integration for local development.
+- Name of the generated ZIP file containing the lambdas. 
+
 ## (2020-07-13)
 CloudFormation updated to support using an AWS VPC for lambda ingesters and for the backfiller to be able to be run automatically when created.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,10 +140,10 @@ To update the version, follow these steps:
 2. Locally, check out the `master` branch and pull from `origin/mater`.
 3. Use __ to bump the project version.
 
-    * To craete a patch run: ``
-    * To create a minor run: ``
-    * To create a major run: ``
-    
+    * To craete a patch run: `bump2version patch`
+    * To create a minor run: `bump2version minor`
+    * To create a major run: `bump2version major`
+
 4. Run `` to push changes.
 5. Run the `deploy.sh` script. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Following is described how to set up the integration for local development.
             pip3 install -r requirements.txt -t target
             ```
 
-      3. In the *target* folder, zip all files into *YOUR-ZIP-NAME.zip*. 
+      3. In the *target* folder, zip all files into *v0.0.0_YOUR-ZIP-FILE.zip*. Choose whatever version number is relevant to you.  
 
 3. Create an AWS S3 bucket using the following command: 
 
@@ -51,12 +51,12 @@ Following is described how to set up the integration for local development.
     aws s3api create-bucket --bucket YOUR-HUMIO-BUCKET --create-bucket-configuration LocationConstraint=YOUR-REGION
     ```
 
-    - The name of the AWS S3 bucket must be the same as the one specified in the CloudFormation file.
+    - The name of the AWS S3 bucket must be the same as the one specified in the CloudFormation file. The default name is `humio-public-YOUR-REGION`.
 
 4. Upload the zip file to the AWS S3 bucket: 
 
     ```
-    aws s3 cp target/YOUR-ZIP-NAME.zip s3://YOUR-HUMIO-BUCKET/
+    aws s3 cp target/v0.0.0_YOUR-ZIP-FILE.zip s3://YOUR-HUMIO-BUCKET/
     ``` 
 
 5. Create a *parameters.json* file in the project root folder, and specify the CloudFormation parameters, for example: 
@@ -76,22 +76,18 @@ Following is described how to set up the integration for local development.
             "ParameterValue": "YOUR-SECRET-INGEST-TOKEN" 
         },
         { 
-            "ParameterKey": "HumioCloudWatchLogsAutoSubscription", 
-            "ParameterValue": "true" 
-        },
-        { 
             "ParameterKey": "HumioCloudWatchLogsSubscriptionPrefix", 
             "ParameterValue": "humio" 
         },
         {
-            "ParameterKey": "S3KeyNameForZipWithLambdas",
-            "ParameterValue": "YOUR-ZIP-NAME.zip"
+            "ParameterKey": "Version",
+            "ParameterValue": "v0.0.0"
         }
     ]
     ```
 
     - Only the  `HumioIngestToken` parameter is required to be specified in the *parameters.json* file as the rest have default values.
-    - The `S3KeyNameForZipWithLambdas` is important though, as this is were CloudFormation will look for the lambda files. Its default value should be that of the latest integration version, for example, *v1.0.0_cloudwatch2humio.zip*.
+    - The `Version` must match the version number given in the name of the ZIP file you have uploaded.
 
 6. Create the stack using the CloudFormation file and the parameters that you have defined: 
 
@@ -103,13 +99,13 @@ Following is described how to set up the integration for local development.
 
 7. Upating the stack.
 
-    - To update the stack, use the following command: 
+    - To update the stack, add your changes and use the command: 
     
         ```
         aws cloudformation update-stack --stack-name YOUR-DESIRED-STACK-NAME --template-body file://cloudformation.json --parameters file://parameters.json --capabilities CAPABILITY_IAM --region YOUR-REGION
         ```
 
-    - Note: The stack will only register changes in the CloudFormation file or in the parameters' file. If you have updated the lambda files, you need to change the name of the zip file, and thus the parameter `S3KeyNameForZipWithLambdas` for your changes to be recognized.
+    - Note: The stack will only register changes in the CloudFormation file or in the parameters' file. If you have updated the lambda files, you need to change the name of the version of the ZIP file, and thus the parameter `Version` for your changes to be recognized.
 
 8. Deleting the stack.
 
@@ -123,13 +119,11 @@ Following is described how to set up the integration for local development.
 When you have made your changes locally, or you want feedback on a work in progress, you're almost ready to make a pull request. Before doing so however, please go through the following checklist:
 
 1. Test the integration and make sure that all features are still functional.
-2. Update the version number of the ZIP file in the `Makefile` and of the default value of the `S3KeyNameForZipWithLambdas` parameter in the `cloudformation.json` file. These should always match.
-3. Update the `CHANGELOG.md`.
-3. Add yourself to `AUTHORS.md`.
+2. Add yourself to `AUTHORS.md`.
 
 When you've been through the checklist, push your final changes to your development branch on GitHub.
 
-Congratulations! Your branch is now ready to be included submitted as a pull requests. Got to [cloudwatch2humio](https://github.com/humio/cloudwatch2humio) and use the pull request feature to submit your contribution for review.
+Congratulations! Your branch is now ready to be included submitted as a pull requests. Go to [cloudwatch2humio](https://github.com/humio/cloudwatch2humio) and use the pull request feature to submit your contribution for review.
 
 ## For Maintainers: How to Release
 When a new release of the integration needs to be uploaded to the S3 buckets hosting the lambda files, the version of the integration needs to be updated.
@@ -138,14 +132,14 @@ To update the version, follow these steps:
 
 1. Make sure `CHANGELOG.md` has an entry for the new release version.
 2. Locally, check out the `master` branch and pull from `origin/mater`.
-3. Use __ to bump the project version.
+3. Use `bump2version` to bump the project version and create a commit.
 
     * To craete a patch run: `bump2version patch`
     * To create a minor run: `bump2version minor`
     * To create a major run: `bump2version major`
 
-4. Run `` to push changes.
-5. Run the `deploy.sh` script. 
+4. Push your changes.
+5. Run the `deploy.sh` script - access rights required. 
 
 Terms of Service For Contributors
 =================================

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ Following is described how to set up the integration for local development.
         },
         {
             "ParameterKey": "Version",
-            "ParameterValue": "v0.0.0"
+            "ParameterValue": "YOUR-VERSION-HERE"
         }
     ]
     ```
@@ -138,8 +138,8 @@ To update the version, follow these steps:
     * To create a minor run: `bump2version minor`
     * To create a major run: `bump2version major`
 
-4. Push your changes.
-5. Run the `deploy.sh` script - access rights required. 
+4. Run `git push --follow-tags` to push changes and initialize the release process.
+5. Run the `deploy.sh` script to upload the CloudFormation file to a S3 bucket as well as the zip file to each supported region's S3 bucket. 
 
 Terms of Service For Contributors
 =================================

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,20 +43,20 @@ Following is described how to set up the integration for local development.
             pip3 install -r requirements.txt -t target
             ```
 
-      3. In the *target* folder, zip all files into *cloudwatch_humio.zip*. 
+      3. In the *target* folder, zip all files into *YOUR-ZIP-NAME.zip*. 
 
 3. Create an AWS S3 bucket using the following command: 
 
     ```
-    aws s3api create-bucket --bucket humio-public-YOUR-REGION --create-bucket-configuration LocationConstraint=YOUR-REGION
+    aws s3api create-bucket --bucket YOUR-HUMIO-BUCKET --create-bucket-configuration LocationConstraint=YOUR-REGION
     ```
 
-    - The name of the AWS S3 bucket must be the same as the one specified in the CloudFormation file, beware of this if you choose another name.
+    - The name of the AWS S3 bucket must be the same as the one specified in the CloudFormation file.
 
 4. Upload the zip file to the AWS S3 bucket: 
 
     ```
-    aws s3 cp target/cloudwatch_humio.zip s3://humio-public-YOUR-REGION/
+    aws s3 cp target/YOUR-ZIP-NAME.zip s3://YOUR-HUMIO-BUCKET/
     ``` 
 
 5. Create a *parameters.json* file in the project root folder, and specify the CloudFormation parameters, for example: 
@@ -82,11 +82,16 @@ Following is described how to set up the integration for local development.
         { 
             "ParameterKey": "HumioCloudWatchLogsSubscriptionPrefix", 
             "ParameterValue": "humio" 
+        },
+        {
+            "ParameterKey": "S3KeyNameForZipWithLambdas",
+            "ParameterValue": "YOUR-ZIP-NAME.zip"
         }
     ]
     ```
 
     - Only the  `HumioIngestToken` parameter is required to be specified in the *parameters.json* file as the rest have default values.
+    - The `S3KeyNameForZipWithLambdas` is important though, as this is were CloudFormation will look for the lambda files. Its default value should be that of the latest integration version, for example, *v1.0.0_cloudwatch2humio.zip*.
 
 6. Create the stack using the CloudFormation file and the parameters that you have defined: 
 
@@ -98,29 +103,49 @@ Following is described how to set up the integration for local development.
 
 7. Upating the stack.
 
-    - Depending on your changes, you will either have to delete the stack and create it again using the CloudFormation file, or you can update the stack. 
-
-        - Update the stack:
+    - To update the stack, use the following command: 
     
-            ```
-            aws cloudformation update-stack --stack-name YOUR-DESIRED-STACK-NAME --template-body file://cloudformation.json --parameters file://parameters.json --capabilities CAPABILITY_IAM --region YOUR-REGION
-            ```
+        ```
+        aws cloudformation update-stack --stack-name YOUR-DESIRED-STACK-NAME --template-body file://cloudformation.json --parameters file://parameters.json --capabilities CAPABILITY_IAM --region YOUR-REGION
+        ```
 
-        - Delete the stack:
-    
-            ```
-            aws cloudformation delete-stack --stack-name YOUR-DESIRED-STACK-NAME
-            ```
+    - Note: The stack will only register changes in the CloudFormation file or in the parameters' file. If you have updated the lambda files, you need to change the name of the zip file, and thus the parameter `S3KeyNameForZipWithLambdas` for your changes to be recognized.
+
+8. Deleting the stack.
+
+    - To delete the stack, use the following command:
+
+        ```
+        aws cloudformation delete-stack --stack-name YOUR-DESIRED-STACK-NAME
+        ```
 
 ## Making a Pull Request
 When you have made your changes locally, or you want feedback on a work in progress, you're almost ready to make a pull request. Before doing so however, please go through the following checklist:
 
 1. Test the integration and make sure that all features are still functional.
-3. Add yourself to ``AUTHORS.md``.
+2. Update the version number of the ZIP file in the `Makefile` and of the default value of the `S3KeyNameForZipWithLambdas` parameter in the `cloudformation.json` file. These should always match.
+3. Update the `CHANGELOG.md`.
+3. Add yourself to `AUTHORS.md`.
 
 When you've been through the checklist, push your final changes to your development branch on GitHub.
 
 Congratulations! Your branch is now ready to be included submitted as a pull requests. Got to [cloudwatch2humio](https://github.com/humio/cloudwatch2humio) and use the pull request feature to submit your contribution for review.
+
+## For Maintainers: How to Release
+When a new release of the integration needs to be uploaded to the S3 buckets hosting the lambda files, the version of the integration needs to be updated.
+
+To update the version, follow these steps:
+
+1. Make sure `CHANGELOG.md` has an entry for the new release version.
+2. Locally, check out the `master` branch and pull from `origin/mater`.
+3. Use __ to bump the project version.
+
+    * To craete a patch run: ``
+    * To create a minor run: ``
+    * To create a major run: ``
+    
+4. Run `` to push changes.
+5. Run the `deploy.sh` script. 
 
 Terms of Service For Contributors
 =================================

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-build: clean target copy dependencies target/cloudwatch_humio.zip
+build: clean target copy dependencies target/cloudwatch2humio.zip
 
 clean:
-	rm -rf target/cloudwatch_humio.zip
+	rm -rf target/*
 
 target:
 	mkdir -p target
@@ -12,8 +12,8 @@ copy:
 dependencies:
 	pip3 install -r requirements.txt -t target
 
-target/cloudwatch_humio.zip:
-	(cd target/ && zip -r ../target/cloudwatch_humio.zip * )
+target/cloudwatch2humio.zip:
+	(cd target/ && zip -r ../target/v1.0.0-cloudwatch2humio.zip * )
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dependencies:
 	pip3 install -r requirements.txt -t target
 
 target/cloudwatch2humio.zip:
-	(cd target/ && zip -r ../target/cloudwatch2humio.zip * )
+	(cd target/ && zip -r ../target/v.0.0.0_cloudwatch2humio.zip * )
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dependencies:
 	pip3 install -r requirements.txt -t target
 
 target/cloudwatch2humio.zip:
-	(cd target/ && zip -r ../target/v.v0.1.0_cloudwatch2humio.zip * )
+	(cd target/ && zip -r ../target/v0.1.0_cloudwatch2humio.zip * )
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dependencies:
 	pip3 install -r requirements.txt -t target
 
 target/cloudwatch2humio.zip:
-	(cd target/ && zip -r ../target/v0.1.0_cloudwatch2humio.zip * )
+	(cd target/ && zip -r ../target/v0.2.0_cloudwatch2humio.zip * )
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dependencies:
 	pip3 install -r requirements.txt -t target
 
 target/cloudwatch2humio.zip:
-	(cd target/ && zip -r ../target/v0.0.0_cloudwatch2humio.zip * )
+	(cd target/ && zip -r ../target/v1.0.0_cloudwatch2humio.zip * )
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dependencies:
 	pip3 install -r requirements.txt -t target
 
 target/cloudwatch2humio.zip:
-	(cd target/ && zip -r ../target/v.0.0.0_cloudwatch2humio.zip * )
+	(cd target/ && zip -r ../target/v.v0.1.0_cloudwatch2humio.zip * )
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dependencies:
 	pip3 install -r requirements.txt -t target
 
 target/cloudwatch2humio.zip:
-	(cd target/ && zip -r ../target/v0.2.0_cloudwatch2humio.zip * )
+	(cd target/ && zip -r ../target/v0.0.0_cloudwatch2humio.zip * )
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dependencies:
 	pip3 install -r requirements.txt -t target
 
 target/cloudwatch2humio.zip:
-	(cd target/ && zip -r ../target/v1.0.0-cloudwatch2humio.zip * )
+	(cd target/ && zip -r ../target/cloudwatch2humio.zip * )
 
 clean:
 	rm -rf target

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 
 # CloudWatch2Humio
-This repository contains a set of lambdas for shipping Cloudwatch Logs and Metrics
-to Humio.
+This repository contains a set of lambdas for shipping Cloudwatch Logs and Metrics to Humio.
 
 The full documentation regarding installing and using this integration can be found in the official [humio docs](https://docs.humio.com/integrations/platforms/aws-cloudwatch/).
 

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -170,7 +170,7 @@
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
-            "Fn:Join" : [ "-", [ { "Ref" : "S3KeyNameForZipWithLambdas" }, "_cloudwatch2humio.zip" ] ]
+            "Fn:Join" : [ "-", [ { "Ref" : "Version" }, "_cloudwatch2humio.zip" ] ]
         },
         "Environment" : {
           "Variables" : {
@@ -218,7 +218,8 @@
           "S3Bucket" : {
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
-          "S3Key" : { "Ref" : "S3KeyNameForZipWithLambdas" }
+          "S3Key" : {
+            "Fn:Join" : [ "-", [ { "Ref" : "Version" }, "_cloudwatch2humio.zip" ] ]
         },
         "Environment" : {
           "Variables" : {
@@ -272,7 +273,8 @@
           "S3Bucket" : {
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
-          "S3Key" : { "Ref" : "S3KeyNameForZipWithLambdas" }
+          "S3Key" : {
+            "Fn:Join" : [ "-", [ { "Ref" : "Version" }, "_cloudwatch2humio.zip" ] ]
         },
         "Environment" : {
           "Variables" : {
@@ -416,7 +418,8 @@
           "S3Bucket" : {
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
-          "S3Key" : { "Ref" : "S3KeyNameForZipWithLambdas" }
+          "S3Key" : {
+            "Fn:Join" : [ "-", [ { "Ref" : "Version" }, "_cloudwatch2humio.zip" ] ]
         },
         "Environment" : {
           "Variables" : {
@@ -464,7 +467,8 @@
           "S3Bucket" : {
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
-          "S3Key" : { "Ref" : "S3KeyNameForZipWithLambdas" }
+          "S3Key" : {
+            "Fn:Join" : [ "-", [ { "Ref" : "Version" }, "_cloudwatch2humio.zip" ] ]
         },
         "Environment" : {
           "Variables" : {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -443,7 +443,7 @@
             }
           ]
         },
-        "Description" : "CloudWatch metrics to Humio ingester.",
+        "Description" : "CloudWatch Metrics to Humio ingester.",
         "Handler" : "metric_ingester.lambda_handler",
         "MemorySize" : "128",
         "Role" : {
@@ -493,7 +493,7 @@
             }
           ]
         },
-        "Description" : "CloudWatch metrics statistics to Humio ingester.",
+        "Description" : "CloudWatch Metrics Statistics to Humio ingester.",
         "Handler" : "metric_statistics_ingester.lambda_handler",
         "MemorySize" : "128",
         "Role" : {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -61,7 +61,7 @@
     "Version" : {
       "Type" : "String",
       "Description" : "The version of the integration you want installed.",
-      "Default" : "v0.0.0"
+      "Default" : "v1.0.0"
     }
   },
   "Conditions" : {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -170,7 +170,8 @@
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
-            "Fn:Join" : [ "-", [ { "Ref" : "Version" }, "_cloudwatch2humio.zip" ] ]
+            "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
+          }
         },
         "Environment" : {
           "Variables" : {
@@ -219,7 +220,8 @@
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
-            "Fn:Join" : [ "-", [ { "Ref" : "Version" }, "_cloudwatch2humio.zip" ] ]
+            "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
+          }
         },
         "Environment" : {
           "Variables" : {
@@ -274,7 +276,8 @@
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
-            "Fn:Join" : [ "-", [ { "Ref" : "Version" }, "_cloudwatch2humio.zip" ] ]
+            "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
+          }
         },
         "Environment" : {
           "Variables" : {
@@ -419,7 +422,8 @@
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
-            "Fn:Join" : [ "-", [ { "Ref" : "Version" }, "_cloudwatch2humio.zip" ] ]
+            "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
+          }
         },
         "Environment" : {
           "Variables" : {
@@ -468,7 +472,8 @@
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
-            "Fn:Join" : [ "-", [ { "Ref" : "Version" }, "_cloudwatch2humio.zip" ] ]
+            "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
+          }
         },
         "Environment" : {
           "Variables" : {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -61,7 +61,7 @@
     "S3KeyNameForZipWithLambdas" : {
       "Type" : "String",
       "Description" : "The name of the ZIP file in where to find the integration's lambda files.",
-      "Default" : "v0.0.0-cloudwatch2humio"
+      "Default" : "v0.1.0-cloudwatch2humio"
     }
   },
   "Conditions" : {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -61,7 +61,7 @@
     "S3KeyNameForZipWithLambdas" : {
       "Type" : "String",
       "Description" : "The name of the ZIP file in where to find the integration's lambda files.",
-      "Default" : "v1.0.0-cloudwatch2humio"
+      "Default" : "v0.0.0-cloudwatch2humio"
     }
   },
   "Conditions" : {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -61,7 +61,7 @@
     "S3KeyNameForZipWithLambdas" : {
       "Type" : "String",
       "Description" : "The name of the ZIP file in where to find the integration's lambda files.",
-      "Default" : "v0.1.0-cloudwatch2humio"
+      "Default" : "v0.2.0-cloudwatch2humio"
     }
   },
   "Conditions" : {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -58,10 +58,10 @@
       "Type" : "CommaDelimitedList",
       "Description" : "A comma separated list of subnet ids used by the VPC configuration that the ingester lamda functions will be deployed into. Only required if VPC is enabled."
     },
-    "S3KeyNameForZipWithLambdas" : {
+    "Version" : {
       "Type" : "String",
-      "Description" : "The name of the ZIP file in where to find the integration's lambda files.",
-      "Default" : "v0.2.0-cloudwatch2humio"
+      "Description" : "The version of the integration you want installed.",
+      "Default" : "v0.0.0"
     }
   },
   "Conditions" : {
@@ -169,7 +169,8 @@
           "S3Bucket" : {
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
-          "S3Key" : { "Ref" : "S3KeyNameForZipWithLambdas" }
+          "S3Key" : {
+            "Fn:Join" : [ "-", [ { "Ref" : "S3KeyNameForZipWithLambdas" }, "_cloudwatch2humio.zip" ] ]
         },
         "Environment" : {
           "Variables" : {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -57,6 +57,11 @@
     "SubnetIds" : {
       "Type" : "CommaDelimitedList",
       "Description" : "A comma separated list of subnet ids used by the VPC configuration that the ingester lamda functions will be deployed into. Only required if VPC is enabled."
+    },
+    "S3KeyNameForZipWithLambdas" : {
+      "Type" : "String",
+      "Description" : "The name of the ZIP file in where to find the integration's lambda files.",
+      "Default" : "v1.0.0-cloudwatch2humio"
     }
   },
   "Conditions" : {
@@ -164,7 +169,7 @@
           "S3Bucket" : {
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
-          "S3Key" : "cloudwatch_humio.zip"
+          "S3Key" : { "Ref" : "S3KeyNameForZipWithLambdas" }
         },
         "Environment" : {
           "Variables" : {
@@ -212,7 +217,7 @@
           "S3Bucket" : {
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
-          "S3Key" : "cloudwatch_humio.zip"
+          "S3Key" : { "Ref" : "S3KeyNameForZipWithLambdas" }
         },
         "Environment" : {
           "Variables" : {
@@ -266,7 +271,7 @@
           "S3Bucket" : {
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
-          "S3Key" : "cloudwatch_humio.zip"
+          "S3Key" : { "Ref" : "S3KeyNameForZipWithLambdas" }
         },
         "Environment" : {
           "Variables" : {
@@ -410,7 +415,7 @@
           "S3Bucket" : {
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
-          "S3Key" : "cloudwatch_humio.zip"
+          "S3Key" : { "Ref" : "S3KeyNameForZipWithLambdas" }
         },
         "Environment" : {
           "Variables" : {
@@ -458,7 +463,7 @@
           "S3Bucket" : {
             "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
           },
-          "S3Key" : "cloudwatch_humio.zip"
+          "S3Key" : { "Ref" : "S3KeyNameForZipWithLambdas" }
         },
         "Environment" : {
           "Variables" : {

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,11 +5,11 @@ make build
 
 aws s3 cp --acl public-read cloudformation.json s3://humio-public-us-east-1/ --region us-east-1
 
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-eu-central-1/ --region eu-central-1
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-eu-west-1/ --region eu-west-1
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-eu-west-2/ --region eu-west-2
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-eu-north-1/  --region eu-north-1
+aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-eu-central-1/ --region eu-central-1
+aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-eu-west-1/ --region eu-west-1
+aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-eu-west-2/ --region eu-west-2
+aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-eu-north-1/  --region eu-north-1
 
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-east-1/ --region us-east-1
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-east-2/ --region us-east-2
-aws s3 cp --acl public-read target/cloudwatch_humio.zip s3://humio-public-us-west-2/ --region us-west-2
+aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-us-east-1/ --region us-east-1
+aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-us-east-2/ --region us-east-2
+aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-us-west-2/ --region us-west-2

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,11 +5,11 @@ make build
 
 aws s3 cp --acl public-read cloudformation.json s3://humio-public-us-east-1/ --region us-east-1
 
-aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-eu-central-1/ --region eu-central-1
-aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-eu-west-1/ --region eu-west-1
-aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-eu-west-2/ --region eu-west-2
-aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-eu-north-1/  --region eu-north-1
+aws s3 cp --acl public-read target/v1.0.0_cloudwatch2humio.zip s3://humio-public-eu-central-1/ --region eu-central-1
+aws s3 cp --acl public-read target/v1.0.0_cloudwatch2humio.zip s3://humio-public-eu-west-1/ --region eu-west-1
+aws s3 cp --acl public-read target/v1.0.0_cloudwatch2humio.zip s3://humio-public-eu-west-2/ --region eu-west-2
+aws s3 cp --acl public-read target/v1.0.0_cloudwatch2humio.zip s3://humio-public-eu-north-1/  --region eu-north-1
 
-aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-us-east-1/ --region us-east-1
-aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-us-east-2/ --region us-east-2
-aws s3 cp --acl public-read target/v0.0.0_cloudwatch2humio.zip s3://humio-public-us-west-2/ --region us-west-2
+aws s3 cp --acl public-read target/v1.0.0_cloudwatch2humio.zip s3://humio-public-us-east-1/ --region us-east-1
+aws s3 cp --acl public-read target/v1.0.0_cloudwatch2humio.zip s3://humio-public-us-east-2/ --region us-east-2
+aws s3 cp --acl public-read target/v1.0.0_cloudwatch2humio.zip s3://humio-public-us-west-2/ --region us-west-2


### PR DESCRIPTION
Support for changing which version of the integration is to be used has been added. 
- A parameter in the CloudFormation file has been added to determine which version of the lambda files is to be used in the integration. A user can thus change and update the version of the lambda files used by the integration by updating their CloudFormation stack and changing its parameters.
- Maintainers are now required to version control their uploads of the lambda files. 
- bump2version has been added to the project for making it easier to maintain the versioning of the integration. 