### PR TITLE
Fix performance regression

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -11,9 +11,14 @@ logging.basicConfig(level=level)
 logger = logging.getLogger()
 logger.setLevel(level)
 
+_is_setup = False
+
 def setup():
     """
     Sets up variables that should persists across Lambda invocations.
+
+    This can be called every invocation but we will only run it once
+    per Lambda instance.
     """
     global humio_host
     global humio_protocol
@@ -21,10 +26,14 @@ def setup():
     global http_session
     global _is_setup
 
+    if _is_setup:
+        return
+
     humio_host = os.environ["humio_host"]
     humio_protocol = os.environ["humio_protocol"]
     humio_ingest_token = os.environ["humio_ingest_token"]
     http_session = requests.Session()
+
     _is_setup = True
 
 

--- a/src/logs_ingester.py
+++ b/src/logs_ingester.py
@@ -9,8 +9,6 @@ logging.basicConfig(level=level)
 logger = logging.getLogger()
 logger.setLevel(level)
 
-# False when setup has not been performed.
-_is_setup = False
 
 def lambda_handler(event, context):
     """
@@ -25,9 +23,7 @@ def lambda_handler(event, context):
 
     :return: None
     """
-    # Persist variables across lambda invocations.
-    if not _is_setup:
-        helpers.setup()
+    helpers.setup()
 
     # Decode and unzip the log data.
     decoded_event = helpers.decode_event(event)

--- a/src/metric_ingester.py
+++ b/src/metric_ingester.py
@@ -10,8 +10,6 @@ logging.basicConfig(level=level)
 logger = logging.getLogger()
 logger.setLevel(level)
 
-_is_setup = False
-
 
 def lambda_handler(event, context):
     """
@@ -25,9 +23,7 @@ def lambda_handler(event, context):
 
     :return: None
     """
-    # Persist variables across lambda invocations.
-    if not _is_setup:
-        helpers.setup()
+    helpers.setup()
 
     # Load user defined configurations for the API request. 
     configurations = json.load(open("conf_metric_ingester.json", "r"))

--- a/src/metric_statistics_ingester.py
+++ b/src/metric_statistics_ingester.py
@@ -10,8 +10,6 @@ logging.basicConfig(level=level)
 logger = logging.getLogger()
 logger.setLevel(level)
 
-_is_setup = False
-
 
 def lambda_handler(event, context):
     """
@@ -25,9 +23,7 @@ def lambda_handler(event, context):
 
     :return: None
     """
-    # Persist variables across lambda invocations.
-    if not _is_setup:
-        helpers.setup()
+    helpers.setup()
 
     # Load user defined configurations for the API request. 
     configurations = json.load(open("conf_metric_statistics_ingester.json", "r"))


### PR DESCRIPTION
It looks like the performance optimisation introduced in
https://github.com/humio/cloudwatch2humio/pull/9
have been regressed because we are now calling setup() for every
invocation.

This is happening because the `_is_setup` variable being operated on in
helpers.py is different to that in the function files.

To fix this and hopefully prevent this from happening in future we now
scope `_is_setup` to just helpers.py and allow `setup()` to be called on
every invocation.

This has the effect of reducing the average duration from ~900ms -> 25ms
since we aren't creating a new http connection every time.

![image](https://user-images.githubusercontent.com/142294/104311346-f9722100-54cc-11eb-8a66-887c03c160b8.png)
