### PR TITLE
Add S3 Source Bucket Upload Parameter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,18 +45,18 @@ Following is described how to set up the integration for local development.
 
       3. In the *target* folder, zip all files into *v0.0.0_YOUR-ZIP-FILE.zip*. Choose whatever version number is relevant to you.  
 
-3. Create an AWS S3 bucket using the following command: 
+3. Create an AWS S3 bucket for each region you wish to deploy to using the following command: 
 
     ```
-    aws s3api create-bucket --bucket YOUR-HUMIO-BUCKET --create-bucket-configuration LocationConstraint=YOUR-REGION
+    aws s3api create-bucket --bucket YOUR-HUMIO-BUCKET-PREFIX-YOUR-REGION --create-bucket-configuration LocationConstraint=YOUR-REGION
     ```
 
-    - The name of the AWS S3 bucket must be the same as the one specified in the CloudFormation file. The default name is `humio-public-YOUR-REGION`.
+    - The prefix of the AWS S3 bucket must be the same as the one specified in the CloudFormation file with the region appended to it. The default name is `humio-public-YOUR-REGION`.
 
 4. Upload the zip file to the AWS S3 bucket: 
 
     ```
-    aws s3 cp target/v0.0.0_YOUR-ZIP-FILE.zip s3://YOUR-HUMIO-BUCKET/
+    aws s3 cp target/v0.0.0_YOUR-ZIP-FILE.zip s3://YOUR-HUMIO-BUCKET-PREFIX-YOUR-REGION/
     ``` 
 
 5. Create a *parameters.json* file in the project root folder, and specify the CloudFormation parameters, for example: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,10 @@ Following is described how to set up the integration for local development.
             "ParameterValue": "humio" 
         },
         {
+            "ParameterKey": "SourceCodeS3BucketPrefix",
+            "ParameterValue": "YOUR-SOURCE-CODE-BUCKET-PREFIX"
+        }
+        {
             "ParameterKey": "Version",
             "ParameterValue": "YOUR-VERSION-HERE"
         }

--- a/cloudformation-no-trail.json
+++ b/cloudformation-no-trail.json
@@ -68,6 +68,11 @@
       "AllowedValues" : ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
       "Default" : "INFO"
     },
+    "SourceCodeS3BucketPrefix" : {
+      "Type" : "String",
+      "Description" : "The prefix of the S3 bucket name where your Lambda code has been uploaded to. The actual bucket name will be your prefix with \"-<region>\" appended to it (e.g. my-bucket will actually use my-bucket-us-west-2)",
+      "Default" : "humio-public"
+    },
     "Version" : {
       "Type" : "String",
       "Description" : "The version of the integration you want installed.",
@@ -177,7 +182,10 @@
       "Properties" : {
         "Code" : {
           "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+            "Fn::Join" : [
+              "-",
+              [ { "Ref" : "SourceCodeS3BucketPrefix" }, { "Ref" : "AWS::Region"}]
+            ]
           },
           "S3Key" : {
             "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
@@ -238,7 +246,7 @@
       "Properties" : {
         "Code" : {
           "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+            "Fn::Join" : [ "-", [ { "Ref" : "SourceCodeS3BucketPrefix"}, { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
             "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
@@ -305,7 +313,7 @@
       "Properties" : {
         "Code" : {
           "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+            "Fn::Join" : [ "-", [ {"Ref" : "SourceCodeS3BucketPrefix"}, { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
             "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
@@ -397,7 +405,7 @@
       "Properties" : {
         "Code" : {
           "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+            "Fn::Join" : [ "-", [ {"Ref" : "SourceCodeS3BucketPrefix"}, { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
             "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
@@ -458,7 +466,7 @@
       "Properties" : {
         "Code" : {
           "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+            "Fn::Join" : [ "-", [ {"Ref" : "SourceCodeS3BucketPrefix"}, { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
             "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -68,6 +68,11 @@
       "AllowedValues" : ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
       "Default" : "INFO"
     },
+    "SourceCodeS3BucketPrefix" : {
+      "Type" : "String",
+      "Description" : "The prefix of the S3 bucket name where your Lambda code has been uploaded to. The actual bucket name will be your prefix with \"-<region>\" appended to it (e.g. my-bucket will actually use my-bucket-us-west-2)",
+      "Default" : "humio-public"
+    },
     "Version" : {
       "Type" : "String",
       "Description" : "The version of the integration you want installed.",
@@ -177,7 +182,10 @@
       "Properties" : {
         "Code" : {
           "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+            "Fn::Join" : [
+              "-",
+              [ { "Ref" : "SourceCodeS3BucketPrefix" }, { "Ref" : "AWS::Region"}]
+            ]
           },
           "S3Key" : {
             "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
@@ -238,7 +246,7 @@
       "Properties" : {
         "Code" : {
           "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+            "Fn::Join" : [ "-", [ { "Ref" : "SourceCodeS3BucketPrefix"}, { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
             "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
@@ -305,7 +313,7 @@
       "Properties" : {
         "Code" : {
           "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+            "Fn::Join" : [ "-", [ {"Ref" : "SourceCodeS3BucketPrefix"}, { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
             "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
@@ -462,7 +470,7 @@
       "Properties" : {
         "Code" : {
           "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+            "Fn::Join" : [ "-", [ {"Ref" : "SourceCodeS3BucketPrefix"}, { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
             "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]
@@ -523,7 +531,7 @@
       "Properties" : {
         "Code" : {
           "S3Bucket" : {
-            "Fn::Join" : [ "-", [ "humio-public", { "Ref" : "AWS::Region" } ] ]
+            "Fn::Join" : [ "-", [ {"Ref" : "SourceCodeS3BucketPrefix"}, { "Ref" : "AWS::Region" } ] ]
           },
           "S3Key" : {
             "Fn::Join" : [ "_", [ { "Ref" : "Version" }, "cloudwatch2humio.zip" ] ]


### PR DESCRIPTION
If using the CFT, one has no choice but to pull source code from
humio-public S3 buckets. This adds a CFT parameter that specifies what
bucket the source code should come from.