### PR TITLE
Fix: Network connection issues fail silently

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -63,21 +63,13 @@ def ingest_events(humio_events, host_type):
     logger.debug("Data being sent to Humio: %s" % wrapped_data)
 
     # Make request but raise an exception for network issues
-    try:
-        request = http_session.post(
-            humio_url,
-            data=json.dumps(wrapped_data),
-            headers=humio_headers
-        )
-    except requests.exceptions.HTTPError as errh:
-        print("Http Error:", errh)
-    except requests.exceptions.ConnectionError as errc:
-        print("Error Connecting:", errc)
-    except requests.exceptions.Timeout as errt:
-        print("Timeout Error:", errt)
-    except requests.exceptions.RequestException as err:
-        print("Request Error: ", err)
-
+    request = http_session.post(
+        humio_url,
+        data=json.dumps(wrapped_data),
+        headers=humio_headers
+    )
+    request.raise_for_status()
+    
     return request
 
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -62,12 +62,22 @@ def ingest_events(humio_events, host_type):
 
     logger.debug("Data being sent to Humio: %s" % wrapped_data)
 
-    # Make request. 
-    request = http_session.post(
-        humio_url,
-        data=json.dumps(wrapped_data),
-        headers=humio_headers
-    )
+    # Make request but raise an exception for network issues
+    try:
+        request = http_session.post(
+            humio_url,
+            data=json.dumps(wrapped_data),
+            headers=humio_headers
+        )
+    except requests.exceptions.HTTPError as errh:
+        print("Http Error:", errh)
+    except requests.exceptions.ConnectionError as errc:
+        print("Error Connecting:", errc)
+    except requests.exceptions.Timeout as errt:
+        print("Timeout Error:", errt)
+    except requests.exceptions.RequestException as err:
+        print("Request Error: ", err)
+
     return request
 
 


### PR DESCRIPTION
This ensures that network issues are raised as exceptions instead of failing silently. During a recent Humio outage we noticed that our lambda did not log any HTTP errors which was traced back to this request.

Example Test:
```python
#!/usr/bin/python

import requests

http_session = requests.Session()

request = http_session.post('https://httpbin.org/status/503', data={}, headers={})
request
# Nothing raised/logged


request = http_session.post('https://httpbin.org/status/503', data={}, headers={})
request.raise_for_status()
# Traceback (most recent call last):
#   File "./humio-new-fix.py", line 13, in <module>
#     request.raise_for_status()
#   File "/Users/scottclark/Library/Python/3.8/lib/python/site-packages/requests/models.py", line 1021, in raise_for_status
#     raise HTTPError(http_error_msg, response=self)
# requests.exceptions.HTTPError: 503 Server Error: SERVICE UNAVAILABLE for url: https://httpbin.org/status/503
```